### PR TITLE
chore: open generic ast under different name

### DIFF
--- a/src/showAstDocument.ts
+++ b/src/showAstDocument.ts
@@ -16,5 +16,10 @@ export class SemgrepDocumentProvider
 }
 
 export function encodeUri(uri: vscode.Uri): vscode.Uri {
-  return uri.with({ scheme: SemgrepDocumentProvider.scheme });
+  // Needs to be a .ml here, regrettably, or you won't get OCaml syntax
+  // highlighting for the tree.
+  return uri.with({
+    path: uri.path + ".semgrep_ast.ml",
+    scheme: SemgrepDocumentProvider.scheme,
+  });
 }


### PR DESCRIPTION
## What:
This PR opens up the "Generic AST" feature of the extension as a different path.

## Why:
This will make it so users cannot erroneously save the Generic AST as their real file.

## How:
Opened it up under the same file name, but appended with `.semgrep_ast.ml`.

Regrettably, we need the `.ml` or else the resulting Generic AST (which is just a dump of OCaml code) will not be highlighted nicely.

## Test plan:
Tried it manually, and it opened under a different name.

Closes PDX-136

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Ran tests locally (VSCode tests cannot run in CI)
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
