### PR TITLE
feat: intrafile scanning using Pro Engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
           "default": true,
           "description": "Only scan lines changed since the last commit"
         },
+        "semgrep.scan.pro_intrafile": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable intrafile scanning using the Semgrep Pro Engine (requires Pro Engine to be already installed)"
+        },
         "semgrep.doHover": {
           "type": "boolean",
           "default": false,

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -82,6 +82,13 @@ function semgrepCmdLineOpts(env: Environment): string[] {
   // Subcommand
   cmdlineOpts.push(...["lsp"]);
 
+  if (env.config.cfg.get("scan.pro_intrafile")) {
+    // This might cause an error if the user has not installed Semgrep Pro Engine
+    // yet on their machine.
+    // Perhaps we should install it automatically for them?
+    cmdlineOpts.push(...["--pro"]);
+  }
+
   // Logging
   if (env.config.trace) {
     cmdlineOpts.push(...["--debug"]);


### PR DESCRIPTION
## What:
This PR adds the extension changes needed to be able to run the Pro Engine from the language server (via toggle).

## Why:
It would be neat if people could do pro scans via the LS, and not be restricted solely to the OSS engine.

## How:
Made a toggle which changes the settings given to the `semgrep` entry point. That script takes care of all of the targeting logic, provided that the user has already done `semgrep install-semgrep-pro`.

Currently just for pro intrafile, because interfile scans would likely be too intensive for an IDE.

## Test plan:
Paired with https://github.com/semgrep/semgrep/pull/9146:
<img width="1314" alt="image" src="https://github.com/semgrep/semgrep-vscode/assets/49291449/c794ea0e-0b4a-4f2d-b694-f51feb1cbc27">
for the rule
```
rules:
  - id: my-other-cool-custom-rule
    pattern-sources:
      - pattern: |
          source()
    pattern-sinks:
      - pattern: |
          sink(...)
    mode: taint
    message: Semgrep found a match
    languages: [python]
    severity: WARNING
```


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Ran tests locally (VSCode tests cannot run in CI)
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
