### PR TITLE
add bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -33,8 +33,8 @@ jobs:
           git add .
           git commit -m "${SUBJECT}"
           git push --set-upstream origin "${BRANCH}"
-          echo "branch=${BRANCH}" >> ${GITHUB_OUTPUT}
-          echo "subject=${SUBJECT}" >> ${GITHUB_OUTPUT}
+          echo "branch=${BRANCH}" >> "${GITHUB_OUTPUT}"
+          echo "subject=${SUBJECT}" >> "${GITHUB_OUTPUT}"
       - name: Create PR
         id: open-pr
         env:
@@ -51,5 +51,4 @@ jobs:
               exit 1
           fi
           # open new pull request with the body of from the local template.
-          res=$(gh pr create --title "${TITLE}" --body "Bump Semgrep Version to ${VERSION}" \
-            --base "${TARGET}" --head "${SOURCE}" --reviewer semgrep/pdx)
+          gh pr create --title "${TITLE}" --body "Bump Semgrep Version to ${VERSION}" --base "${TARGET}" --head "${SOURCE}" --reviewer semgrep/pdx

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,52 @@
+name: bump-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of semgrep to use'
+        required: true
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Commit and push
+        id: commit
+        env:
+          NEW_SEMGREP_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          BRANCH="gha/bump-version-${NEW_SEMGREP_VERSION}-${{ github.run_id }}-${{ github.run_attempt }}"
+          SUBJECT="Bump semgrep to ${NEW_SEMGREP_VERSION}"
+          git checkout -b $BRANCH
+          git add .
+          git commit -m "$SUBJECT"
+          git push --set-upstream origin $BRANCH
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "subject=$SUBJECT" >> $GITHUB_OUTPUT
+      - name: Create PR
+        id: open-pr
+        env:
+          SOURCE: "${{ steps.commit.outputs.branch }}"
+          TARGET: "${{ github.event.repository.default_branch }}"
+          TITLE: "chore: Release Version ${{ inputs.version }}"
+          VERSION: "${{ inputs.version }}"
+        run: |
+          # check if the branch already has a pull request open
+          if gh pr list --head ${SOURCE} | grep -vq "no pull requests"; then
+              # pull request already open
+              echo "pull request from SOURCE ${SOURCE} to TARGET ${TARGET} is already open";
+              echo "cancelling release"
+              exit 1
+          fi
+          # open new pull request with the body of from the local template.
+          res=$(gh pr create --title "${TITLE}" --body "Bump Semgrep Version to ${VERSION}" \
+            --base "${TARGET}" --head "${SOURCE}" --reviewer semgrep/pdx)

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version of semgrep to use'
+        description: "Version of semgrep to use"
         required: true
         type: string
 

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -20,18 +20,21 @@ jobs:
       - name: Commit and push
         id: commit
         env:
-          NEW_SEMGREP_VERSION: ${{ github.event.inputs.version }}
+          NEW_SEMGREP_VERSION: "${{ github.event.inputs.version }}"
+          GITHUB_ACTOR: "${{ github.actor }}"
+          GITHUB_RUN_ID: "${{ github.run_id }}"
+          GITHUB_RUN_ATTEMPT: "${{ github.run_attempt }}"
         run: |
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
-          BRANCH="gha/bump-version-${NEW_SEMGREP_VERSION}-${{ github.run_id }}-${{ github.run_attempt }}"
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          BRANCH="gha/bump-version-${NEW_SEMGREP_VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           SUBJECT="Bump semgrep to ${NEW_SEMGREP_VERSION}"
-          git checkout -b $BRANCH
+          git checkout -b "${BRANCH}"
           git add .
-          git commit -m "$SUBJECT"
-          git push --set-upstream origin $BRANCH
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "subject=$SUBJECT" >> $GITHUB_OUTPUT
+          git commit -m "${SUBJECT}"
+          git push --set-upstream origin "${BRANCH}"
+          echo "branch=${BRANCH}" >> ${GITHUB_OUTPUT}
+          echo "subject=${SUBJECT}" >> ${GITHUB_OUTPUT}
       - name: Create PR
         id: open-pr
         env:
@@ -41,7 +44,7 @@ jobs:
           VERSION: "${{ inputs.version }}"
         run: |
           # check if the branch already has a pull request open
-          if gh pr list --head ${SOURCE} | grep -vq "no pull requests"; then
+          if gh pr list --head "${SOURCE}" | grep -vq "no pull requests"; then
               # pull request already open
               echo "pull request from SOURCE ${SOURCE} to TARGET ${TARGET} is already open";
               echo "cancelling release"


### PR DESCRIPTION
Allows us to automate PR-ing the repo when a new version of Semgrep is released
