### PR TITLE
feat: autofix in new search UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,12 @@
         "when": "semgrep.cli.minor >= 25 || config.semgrep.ignoreCliVersion"
       },
       {
+        "command": "semgrep.search.replaceAll",
+        "title": "Semgrep Search: Replace All Matches",
+        "icon": "$(tools)",
+        "when": "semgrep.cli.minor >= 25 || config.semgrep.ignoreCliVersion"
+      },
+      {
         "command": "semgrep.restartLanguageServer",
         "title": "Semgrep: Restart Language Server"
       }
@@ -227,6 +233,11 @@
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "semgrep.search.replaceAll",
+          "when": "view == semgrep-search-results && semgrep.searchHasFix",
+          "group": "navigation"
+        },
         {
           "command": "semgrep.search.clear",
           "when": "view == semgrep-search-results && semgrep.searchHasResults",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -127,7 +127,6 @@ export function registerCommands(env: Environment): void {
         if (!result) {
           return;
         }
-        console.log(result.locations);
         env.searchView.setSearchItems(result.locations, searchParams);
         vscode.commands.executeCommand("semgrep-search-results.focus");
       }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -109,7 +109,7 @@ export function registerCommands(env: Environment): void {
 
   vscode.commands.registerCommand(
     "semgrep.search",
-    async (searchParams: SearchParams | null, replace: string | null) => {
+    async (searchParams: SearchParams | null) => {
       if (searchParams != null) {
         const result = await env.client?.sendRequest(search, searchParams);
         vscode.commands.executeCommand(
@@ -117,15 +117,18 @@ export function registerCommands(env: Environment): void {
           "semgrep.searchHasResults",
           true
         );
-        vscode.commands.executeCommand(
-          "setContext",
-          "semgrep.searchIsReplace",
-          replace != null
-        );
+        if (searchParams.fix) {
+          vscode.commands.executeCommand(
+            "setContext",
+            "semgrep.searchHasFix",
+            true
+          );
+        }
         if (!result) {
           return;
         }
-        env.searchView.setSearchItems(result.locations, searchParams, replace);
+        console.log(result.locations);
+        env.searchView.setSearchItems(result.locations, searchParams);
         vscode.commands.executeCommand("semgrep-search-results.focus");
       }
     }
@@ -135,8 +138,7 @@ export function registerCommands(env: Environment): void {
     if (env.searchView.lastSearch) {
       vscode.commands.executeCommand(
         "semgrep.search",
-        env.searchView.lastSearch,
-        env.searchView.replace
+        env.searchView.lastSearch
       );
     }
   });
@@ -147,18 +149,33 @@ export function registerCommands(env: Environment): void {
       "semgrep.searchHasResults",
       false
     );
-    vscode.commands.executeCommand(
-      "setContext",
-      "semgrep.searchIsReplace",
-      false
-    );
+    vscode.commands.executeCommand("setContext", "semgrep.searchHasFix", false);
     env.searchView.clearSearch();
   });
 
-  vscode.commands.registerCommand("semgrep.search.replace", () => {
-    env.searchView.replaceAll();
-    vscode.commands.executeCommand("semgrep.search.refresh");
+  vscode.commands.registerCommand("semgrep.search.replaceAll", () => {
+    vscode.commands.executeCommand(
+      "semgrep.search.reallyDoReplaceAllNotification"
+    );
   });
+
+  vscode.commands.registerCommand(
+    "semgrep.search.reallyDoReplaceAllNotification",
+    async () => {
+      const selection = await vscode.window.showWarningMessage(
+        `Really apply fix to ${
+          env.searchView.getFilesWithFixes().length
+        } files?`,
+        "Yes",
+        "No"
+      );
+
+      if (selection === "Yes") {
+        env.searchView.replaceAll();
+        vscode.commands.executeCommand("semgrep.search.refresh");
+      }
+    }
+  );
 
   vscode.commands.registerCommand("semgrep.restartLanguageServer", () => {
     vscode.window.showInformationMessage("Restarting Semgrep Language Server");

--- a/src/interface/commands.ts
+++ b/src/interface/commands.ts
@@ -30,4 +30,8 @@
 
 export const search = "webkit/semgrep/search";
 
-export type webkitCommand = { command: typeof search; pattern: string };
+export type webkitCommand = {
+  command: typeof search;
+  pattern: string;
+  fix: string | null;
+};

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -32,6 +32,7 @@ export interface LoginStatusParams {
 export interface SearchParams {
   pattern: string;
   language: string | null;
+  fix: string | null;
 }
 
 export interface SearchResults {

--- a/src/views/search.ts
+++ b/src/views/search.ts
@@ -21,8 +21,9 @@ export class SemgrepSearchWebviewProvider
         const searchParams: SearchParams = {
           pattern: data.pattern,
           language: null,
+          fix: data.fix,
         };
-        vscode.commands.executeCommand("semgrep.search", searchParams, null);
+        vscode.commands.executeCommand("semgrep.search", searchParams);
       }
     }
   }

--- a/src/webview-ui/App.tsx
+++ b/src/webview-ui/App.tsx
@@ -2,21 +2,49 @@ import { vscode } from "./utilities/vscode";
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import "./App.css";
 import { webkitCommand } from "../interface/commands";
+import { useState } from "react";
 
 const App: React.FC = () => {
+  const [pattern, setPattern] = useState("");
+  const [fix, setFix] = useState("");
+
+  function searchQuery(pattern: string, fix: string) {
+    const fixValue = fix === "" ? null : fix;
+    vscode.postMessage({
+      command: "webkit/semgrep/search",
+      pattern: pattern,
+      fix: fixValue,
+    } as webkitCommand);
+  }
+
   return (
     <main>
       <VSCodeTextField
         autofocus
         placeholder="Pattern"
         style={{ padding: "4px 0", width: "100%" }}
-        onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+        onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
           if (e.key == "Enter") {
-            vscode.postMessage({
-              command: "webkit/semgrep/search",
-              pattern: e.currentTarget.value,
-            } as webkitCommand);
+            searchQuery(e.currentTarget.value, fix);
           }
+        }}
+        // I literally have no idea what the type of this or the below handler should be
+        // We use the onChange here because there's a delta between when the onKeyPress
+        // is fired and when the value is updated
+        onChange={(e: any) => {
+          setPattern(e.target.value);
+        }}
+      />
+      <VSCodeTextField
+        placeholder="Autofix"
+        style={{ padding: "4px 0", width: "100%" }}
+        onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+          if (e.key == "Enter") {
+            searchQuery(pattern, e.currentTarget.value);
+          }
+        }}
+        onChange={(e: any) => {
+          setFix(e.target.value);
         }}
       />
     </main>


### PR DESCRIPTION
This is a stacked diff whose parent is https://github.com/semgrep/semgrep-vscode/pull/100.

This PR adds autofix functionality to the new UI. In particular, it adds a place to write the new autofix, and a replace all button.

<img width="306" alt="image" src="https://github.com/semgrep/semgrep-vscode/assets/49291449/0919e638-9982-478c-8a01-907d02ffc972">

Closes CDX-276
Closes CDX-274

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
