### PR TITLE
feat: collapsing matches and match number badges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "node-fetch": "^2.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-icons": "^5.0.1",
         "semver": "^7.5.0",
         "temp-dir": "^3.0.0",
         "vscode-jsonrpc": "^6.0.0",
@@ -4244,6 +4245,14 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -8142,6 +8151,12 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
+    },
+    "react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "requires": {}
     },
     "react-refresh": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -331,6 +331,7 @@
     "node-fetch": "^2.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^5.0.1",
     "semver": "^7.5.0",
     "temp-dir": "^3.0.0",
     "vscode-jsonrpc": "^6.0.0",

--- a/src/webview-ui/src/components/SearchResults/EntryHeader.tsx
+++ b/src/webview-ui/src/components/SearchResults/EntryHeader.tsx
@@ -1,0 +1,41 @@
+import { vscode } from "./../../utilities/vscode";
+import {
+  VSCodeBadge,
+  VSCodeButton,
+  VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react";
+import { useState } from "react";
+import { MatchItem } from "./MatchItem";
+import { ViewResult } from "../../types/results";
+import { PathHeader } from "./PathHeader";
+import { VscChevronDown, VscChevronRight } from "react-icons/vsc";
+
+import styles from "./SearchResults.module.css";
+
+export interface EntryHeaderProps {
+  result: ViewResult;
+  isExpanded: boolean;
+  toggleIsExpanded: () => void;
+}
+export const EntryHeader: React.FC<EntryHeaderProps> = ({
+  result,
+  isExpanded,
+  toggleIsExpanded,
+}) => {
+  const { path } = result;
+  return (
+    <div className={styles["entry-header"]} onClick={toggleIsExpanded}>
+      <div
+        className={styles["collapse-button"]}
+        aria-label="ExpandButton"
+        role="button"
+      >
+        {isExpanded ? <VscChevronDown /> : <VscChevronRight />}
+      </div>
+      <PathHeader path={path} />
+      <VSCodeBadge className={styles["match-num-badge"]}>
+        {result.matches.length}
+      </VSCodeBadge>
+    </div>
+  );
+};

--- a/src/webview-ui/src/components/SearchResults/EntryHeader.tsx
+++ b/src/webview-ui/src/components/SearchResults/EntryHeader.tsx
@@ -1,11 +1,4 @@
-import { vscode } from "./../../utilities/vscode";
-import {
-  VSCodeBadge,
-  VSCodeButton,
-  VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react";
-import { useState } from "react";
-import { MatchItem } from "./MatchItem";
+import { VSCodeBadge } from "@vscode/webview-ui-toolkit/react";
 import { ViewResult } from "../../types/results";
 import { PathHeader } from "./PathHeader";
 import { VscChevronDown, VscChevronRight } from "react-icons/vsc";

--- a/src/webview-ui/src/components/SearchResults/EntryHeader.tsx
+++ b/src/webview-ui/src/components/SearchResults/EntryHeader.tsx
@@ -17,16 +17,16 @@ export const EntryHeader: React.FC<EntryHeaderProps> = ({
 }) => {
   const { path } = result;
   return (
-    <div className={styles["entry-header"]} onClick={toggleIsExpanded}>
+    <div className={styles.entryHeader} onClick={toggleIsExpanded}>
       <div
-        className={styles["collapse-button"]}
+        className={styles.collapseButton}
         aria-label="ExpandButton"
         role="button"
       >
         {isExpanded ? <VscChevronDown /> : <VscChevronRight />}
       </div>
       <PathHeader path={path} />
-      <VSCodeBadge className={styles["match-num-badge"]}>
+      <VSCodeBadge className={styles.matchNumBadge}>
         {result.matches.length}
       </VSCodeBadge>
     </div>

--- a/src/webview-ui/src/components/SearchResults/SearchResultEntry.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResultEntry.tsx
@@ -1,9 +1,9 @@
 import { MatchItem } from "./MatchItem";
 import { ViewResult } from "../../types/results";
-import { PathHeader } from "./PathHeader";
 
 import styles from "./SearchResults.module.css";
 import { EntryHeader } from "./EntryHeader";
+import { useState } from "react";
 
 export interface SearchResultEntryProps {
   result: ViewResult;

--- a/src/webview-ui/src/components/SearchResults/SearchResultEntry.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResultEntry.tsx
@@ -3,6 +3,7 @@ import { ViewResult } from "../../types/results";
 import { PathHeader } from "./PathHeader";
 
 import styles from "./SearchResults.module.css";
+import { EntryHeader } from "./EntryHeader";
 
 export interface SearchResultEntryProps {
   result: ViewResult;
@@ -10,15 +11,22 @@ export interface SearchResultEntryProps {
 export const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
   result,
 }) => {
-  const { path } = result;
+  const [isExpanded, setIsExpanded] = useState(true);
+
   return (
     <div>
-      <PathHeader path={path} />
-      <ul className={styles.matchesList}>
-        {result.matches.map((match) => (
-          <MatchItem uri={result.uri} match={match} />
-        ))}
-      </ul>
+      <EntryHeader
+        result={result}
+        isExpanded={isExpanded}
+        toggleIsExpanded={() => setIsExpanded(!isExpanded)}
+      />
+      {isExpanded && (
+        <ul className={styles.matchesList}>
+          {result.matches.map((match) => (
+            <MatchItem uri={result.uri} match={match} />
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/src/webview-ui/src/components/SearchResults/SearchResults.module.css
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.module.css
@@ -2,8 +2,24 @@
 
 .matches-summary {
   color: var(--vscode-search-resultsInfoForeground);
-  padding: 0 4px 8px;
+  padding: 8px 4px 8px;
   line-height: 1.4em;
+}
+
+/* ENTRY HEADERS */
+
+.entry-header {
+  display: flex;
+  margin: 5px 0;
+  cursor: pointer;
+}
+
+.match-num-badge {
+  margin-left: auto;
+}
+
+.collapse-button {
+  padding-right: 5px;
 }
 
 /* PATH HEADERS */
@@ -22,13 +38,18 @@
   text-overflow: ellipsis;
   color: gray;
   margin-left: 0.5em;
+  font-size: 0.9em;
+  /* this little margin-top pushes the smaller font text down a bit, which
+     aligns it with the larger file-name to its left
+   */
+  margin-top: 1px;
 }
 
 /* MATCHES */
 
 .matches-list {
-  padding-left: 10px;
-  margin: 5px 0;
+  padding-left: 22px;
+  margin: 0;
 }
 
 .match-item {
@@ -51,6 +72,7 @@
      boxes cut off for some reason. This fixes it.
    */
   padding-top: 1px;
+  font-size: 13px;
   height: 20px;
   cursor: pointer;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,12 +2111,17 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-icons@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz"
+  integrity sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==
+
 react-refresh@^0.13.0:
   version "0.13.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz"
   integrity sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
 
-react@^17.0.2, react@>=16.9.0, react@17.0.2:
+react@*, react@^17.0.2, react@>=16.9.0, react@17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
This is a stacked diff whose parent is #104.

## What:
This PR adds a chevron to the left of each file's matches, which lets you collapse the matches. It also adds a badge with the number of matches per file to the right.

## Test plan:
Tested manually.

<img width="307" alt="image" src="https://github.com/semgrep/semgrep-vscode/assets/49291449/4572c271-7f56-41ab-80b8-e7f3b35d7b08">

Closes CDX-286


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
