### PR TITLE
feat: fix all button

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -17,7 +17,7 @@ import { encodeUri } from "./showAstDocument";
 import { SearchResult, getPreviewChunks } from "./searchResultsTree";
 import { ViewResults } from "./webview-ui/src/types/results";
 import * as path from "path";
-import { applyFixAndSave } from "./utils";
+import { applyFixAndSave, replaceAll } from "./utils";
 
 /*****************************************************************************/
 /* Prelude */
@@ -232,15 +232,19 @@ export function registerCommands(env: Environment): void {
     env.searchView.clearSearch();
   });
 
-  vscode.commands.registerCommand("semgrep.search.replaceAll", () => {
-    vscode.commands.executeCommand(
-      "semgrep.search.reallyDoReplaceAllNotification"
-    );
-  });
+  vscode.commands.registerCommand(
+    "semgrep.search.replaceAll",
+    (matches: ViewResults) => {
+      vscode.commands.executeCommand(
+        "semgrep.search.reallyDoReplaceAllNotification",
+        matches
+      );
+    }
+  );
 
   vscode.commands.registerCommand(
     "semgrep.search.reallyDoReplaceAllNotification",
-    async () => {
+    async (matches: ViewResults) => {
       const selection = await vscode.window.showWarningMessage(
         `Really apply fix to ${
           env.searchView.getFilesWithFixes().length
@@ -250,7 +254,7 @@ export function registerCommands(env: Environment): void {
       );
 
       if (selection === "Yes") {
-        await env.searchView.replaceAll();
+        await replaceAll(matches);
         vscode.commands.executeCommand("semgrep.search.refresh");
       }
     }

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -40,12 +40,14 @@ export const search = "webview/semgrep/search";
 export const print = "webview/semgrep/print";
 export const select = "webview/semgrep/select";
 export const replace = "webview/semgrep/replace";
+export const replaceAll = "webview/semgrep/replaceAll";
 
 export type webviewToExtensionCommand =
   | { command: typeof search; pattern: string; fix: string | null }
   | { command: typeof print; message: string }
   | { command: typeof select; uri: string; range: vscode.Range }
-  | { command: typeof replace; uri: string; range: vscode.Range; fix: string };
+  | { command: typeof replace; uri: string; range: vscode.Range; fix: string }
+  | { command: typeof replaceAll; matches: ViewResults };
 
 /*****************************************************************************/
 /* Extension to webview commands */

--- a/src/searchResultsTree.ts
+++ b/src/searchResultsTree.ts
@@ -94,22 +94,6 @@ export class SemgrepSearchProvider
     }
   }
 
-  async replaceAll(): Promise<void> {
-    const edit = new vscode.WorkspaceEdit();
-    this.items
-      .filter((i) => i instanceof FileItem)
-      .map((item) => {
-        if (item instanceof FileItem) {
-          item.matches.forEach((match) => {
-            if (item.resourceUri && match.fix) {
-              edit.replace(item.resourceUri, match.range, match.fix);
-            }
-          });
-        }
-      });
-    await applyFixAndSave(edit);
-  }
-
   clearSearch(): void {
     this.lastSearch = null;
     this.fix_text = null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { OutputChannel, Uri } from "vscode";
 import * as vscode from "vscode";
 
 import { LSP_LOG_FILE } from "./constants";
+import { ViewResults } from "./webview-ui/src/types/results";
 
 export const DEFAULT_LSP_LOG_URI = Uri.joinPath(
   Uri.file(tmpdir()),
@@ -42,4 +43,21 @@ export async function applyFixAndSave(
       vscode.workspace.openTextDocument(uri).then((doc) => doc.save())
     )
   );
+}
+
+export async function replaceAll(matches: ViewResults): Promise<void> {
+  const edit = new vscode.WorkspaceEdit();
+  matches.locations.map((result) =>
+    /* We don't want to fix anything which was already fixed. */
+    result.matches.forEach((match) => {
+      if (match.searchMatch.fix) {
+        edit.replace(
+          vscode.Uri.parse(result.uri),
+          match.searchMatch.range,
+          match.searchMatch.fix
+        );
+      }
+    })
+  );
+  await applyFixAndSave(edit);
 }

--- a/src/views/webview.ts
+++ b/src/views/webview.ts
@@ -42,6 +42,13 @@ export class SemgrepSearchWebviewProvider
         vscode.commands.executeCommand("semgrep.search.replace", data);
         break;
       }
+      case "webview/semgrep/replaceAll": {
+        vscode.commands.executeCommand(
+          "semgrep.search.replaceAll",
+          data.matches
+        );
+        break;
+      }
       case "webview/semgrep/select": {
         const uri = vscode.Uri.parse(data.uri);
         // I'm not sure why, but this one doesn't work for some reason:

--- a/src/webview-ui/src/components/SearchResults/SearchResults.module.css
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.module.css
@@ -4,6 +4,12 @@
   color: var(--vscode-search-resultsInfoForeground);
   padding: 8px 4px 8px;
   line-height: 1.4em;
+  display: flex;
+}
+
+.replace-all-button {
+  margin-left: auto;
+  cursor: pointer;
 }
 
 /* ENTRY HEADERS */

--- a/src/webview-ui/src/components/SearchResults/SearchResults.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.tsx
@@ -33,7 +33,7 @@ export const SearchResults: React.FC<SearchResultsProps> = ({ state }) => {
     <div>
       <div className={styles.matchesSummary}>
         {`${numMatches} matches in ${numFiles} files`}
-        <div className={styles["replace-all-button"]} onClick={onFixAll}>
+        <div className={styles.replaceAllButton} onClick={onFixAll}>
           <VscReplaceAll role="button" title="Replace All" tabIndex={0} />
         </div>
       </div>

--- a/src/webview-ui/src/components/SearchResults/SearchResults.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.tsx
@@ -2,6 +2,8 @@ import { State } from "../../types/state";
 
 import styles from "./SearchResults.module.css";
 import { SearchResultEntry } from "./SearchResultEntry";
+import { vscode } from "../../../utilities/vscode";
+import { VscReplaceAll } from "react-icons/vsc";
 
 export interface SearchResultsProps {
   state: State | undefined;
@@ -17,10 +19,23 @@ export const SearchResults: React.FC<SearchResultsProps> = ({ state }) => {
   if (state === undefined) {
     return null;
   }
+
+  function onFixAll() {
+    if (state !== undefined) {
+      vscode.sendMessageToExtension({
+        command: "webview/semgrep/replaceAll",
+        matches: state.results,
+      });
+    }
+  }
+
   return (
     <div>
       <div className={styles.matchesSummary}>
         {`${numMatches} matches in ${numFiles} files`}
+        <div className={styles["replace-all-button"]} onClick={onFixAll}>
+          <VscReplaceAll role="button" title="Replace All" tabIndex={0} />
+        </div>
       </div>
       {state.results.locations.map((result) => (
         <SearchResultEntry result={result} />


### PR DESCRIPTION
This is a stacked diff whose parent is #106.

## What:
This PR adds a button which applies all non-applied fixes.

## Test plan:
Tested manually.
<img width="288" alt="image" src="https://github.com/semgrep/semgrep-vscode/assets/49291449/bfc622bc-c439-4464-9308-0efc387184b9">

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
