### PR TITLE
feat: streaming search

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -35,6 +35,15 @@ export class Environment {
   semgrep_log: Uri = DEFAULT_LSP_LOG_URI;
   private _client: LanguageClient | null = null;
   private _provider: SemgrepSearchWebviewProvider | null = null;
+  /* The scan ID is the (hopefully) unique identifier associated to each
+     /semgrep/search request.
+     The reason why we need it is for synchronization, in the event that
+     a user issues a scan while another one is still completing. We don't
+     have a good way of reaching out to each individual searchLoop()
+     (which is asynchronous) and telling it to stop, so we change this
+     mutable variable so that it knows to stop on its own.
+   */
+  private _scanID: string | null = null;
   private constructor(
     readonly context: ExtensionContext,
     config: Config,
@@ -102,6 +111,14 @@ export class Environment {
       window.showWarningMessage("Semgrep Search Webview not active");
     }
     return this._provider;
+  }
+
+  get scanID(): string | null {
+    return this._scanID;
+  }
+
+  set scanID(val: string | null) {
+    this._scanID = val;
   }
 
   static async create(context: ExtensionContext): Promise<Environment> {

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -43,7 +43,12 @@ export const replace = "webview/semgrep/replace";
 export const replaceAll = "webview/semgrep/replaceAll";
 
 export type webviewToExtensionCommand =
-  | { command: typeof search; pattern: string; fix: string | null }
+  | {
+      command: typeof search;
+      pattern: string;
+      fix: string | null;
+      scanID: string;
+    }
   | { command: typeof print; message: string }
   | { command: typeof select; uri: string; range: vscode.Range }
   | { command: typeof replace; uri: string; range: vscode.Range; fix: string }

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -29,7 +29,15 @@ export interface LoginStatusParams {
   loggedIn: boolean;
 }
 
+// These are the parameters sent from the webview to the extnesion, which
+// is a superset of the parameters sent to the LSP.
+// Hence, the two different types `SearchParams` and `LspSearchParams` here.
 export interface SearchParams {
+  scanID: string;
+  lspParams: LspSearchParams;
+}
+
+export interface LspSearchParams {
   pattern: string;
   language: string | null;
   fix: string | null;
@@ -58,8 +66,12 @@ export const loginStatus = new lc.RequestType0<LoginStatusParams | null, void>(
   "semgrep/loginStatus"
 );
 
-export const search = new lc.RequestType<SearchParams, SearchResults, void>(
+export const search = new lc.RequestType<LspSearchParams, SearchResults, void>(
   "semgrep/search"
+);
+
+export const searchOngoing = new lc.RequestType0<SearchResults, void>(
+  "semgrep/searchOngoing"
 );
 
 export const showAst = new lc.RequestType<ShowAstParams, string, void>(

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,110 @@
+import path = require("path");
+import {
+  SearchParams,
+  SearchResults,
+  search,
+  searchOngoing,
+} from "./lspExtensions";
+import { SearchResult, getPreviewChunks } from "./searchResultsTree";
+import { ViewResults } from "./webview-ui/src/types/results";
+import * as vscode from "vscode";
+import { Environment } from "./env";
+
+/*****************************************************************************/
+/* Helpers */
+/*****************************************************************************/
+
+async function viewResultsOfSearchResults(
+  scanID: string,
+  results: SearchResults
+): Promise<ViewResults> {
+  async function viewResultofSearchResult(result: SearchResult) {
+    const uri = vscode.Uri.parse(result.uri);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const workspacePath = vscode.workspace.workspaceFolders
+      ? vscode.workspace.workspaceFolders[0].uri.fsPath
+      : "";
+    return {
+      uri: result.uri,
+      path: path.relative(workspacePath, uri.fsPath),
+      matches: await Promise.all(
+        result.matches.map(async (match) => {
+          const range = new vscode.Range(match.range.start, match.range.end);
+          const { before, inside, after } = getPreviewChunks(doc, range);
+          return {
+            before: before,
+            inside: inside,
+            after: after,
+            isFixed: false,
+            isDismissed: false,
+            searchMatch: match,
+          };
+        })
+      ),
+    };
+  }
+  return {
+    scanID: scanID,
+    locations: await Promise.all(
+      results.locations.map(viewResultofSearchResult)
+    ),
+  };
+}
+
+/*****************************************************************************/
+/* Searching */
+/*****************************************************************************/
+
+async function searchLoop(
+  scanID: string,
+  env: Environment,
+  results: SearchResults | undefined
+): Promise<void> {
+  if (results === undefined) {
+    return;
+  }
+
+  /* This could only be true if another asynchronous handleSearch occurred,
+     meaning that the search this loop is for has terminated.
+     We need to stop this loop, and send no more results to the webview.
+   */
+  if (env.scanID !== null && scanID !== env.scanID) {
+    return;
+  }
+
+  /* Communicate with the webview! */
+  // console.log(results.locations);
+  const viewResults = await viewResultsOfSearchResults(scanID, results);
+  env.provider?.sendMessageToWebview({
+    command: "extension/semgrep/results",
+    results: viewResults,
+  });
+
+  if (results.locations.length === 0) {
+    /* This means we got no results at all.
+       Time to stop the loop.
+     */
+    env.scanID = null;
+    return;
+  } else {
+    /* Otherwise, the streaming is not done. There are more results coming.
+       Time to loop!
+     */
+    const results = await env.client?.sendRequest(searchOngoing);
+    searchLoop(scanID, env, results);
+  }
+}
+
+export async function handleSearch(
+  env: Environment,
+  searchParams: SearchParams
+): Promise<void> {
+  env.scanID = searchParams.scanID;
+  if (searchParams != null) {
+    const results = await env.client?.sendRequest(
+      search,
+      searchParams.lspParams
+    );
+    searchLoop(searchParams.scanID, env, results);
+  }
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -76,12 +76,15 @@ async function searchLoop(
      meaning that the search this loop is for has terminated.
      We need to stop this loop, and send no more results to the webview.
    */
-  // TODO: This actually has a race condition... if a separate searchLoop
+  // THINK: This could have a race condition... if a separate searchLoop
   // changes the scanID after we pass this check, then we might hit the
   // LSP with a /semgrep/searchOngoing request, _after_ the new
   // /semgrep/search.
   // This means that we will get results for the new search, but not send
   // it to the webview.
+  // INFO: Javascript async functions only yield at `await` points, which
+  // means we could be safe, if not for the fact that `viewResultsOfSearchResults`
+  // is in fact called via `await`.
   if (env.scanID !== null && scanID !== env.scanID) {
     return;
   }
@@ -105,7 +108,7 @@ async function searchLoop(
        Time to loop!
      */
     const results = await env.client?.sendRequest(searchOngoing);
-    searchLoop(scanID, env, results);
+    await searchLoop(scanID, env, results);
   }
 }
 

--- a/src/searchResultsTree.ts
+++ b/src/searchResultsTree.ts
@@ -104,7 +104,7 @@ export class SemgrepSearchProvider
 
   setSearchItems(results: SearchResult[], params: SearchParams): void {
     this.lastSearch = params;
-    this.fix_text = params.fix;
+    this.fix_text = params.lspParams.fix;
 
     this.items = results.map((r) => {
       const uri = vscode.Uri.parse(r.uri);

--- a/src/views/webview.ts
+++ b/src/views/webview.ts
@@ -31,9 +31,12 @@ export class SemgrepSearchWebviewProvider
         //   `Starting search for pattern ${data.command}`
         // );
         const searchParams: SearchParams = {
-          pattern: data.pattern,
-          language: null,
-          fix: data.fix,
+          lspParams: {
+            pattern: data.pattern,
+            language: null,
+            fix: data.fix,
+          },
+          scanID: data.scanID,
         };
         vscode.commands.executeCommand("semgrep.search", searchParams);
         break;

--- a/src/webview-ui/App.tsx
+++ b/src/webview-ui/App.tsx
@@ -1,12 +1,20 @@
 import { vscode } from "./utilities/vscode";
 import "./App.css";
-import { useEffect, useState } from "react";
-import { TopSection } from "./src/components/TopSection/TopSection";
+import { useState } from "react";
 import { SearchResults } from "./src/components/SearchResults/SearchResults";
+import { TopSection } from "./src/components/TopSection/TopSection";
 import { State } from "./src/types/state";
+import { ViewResults } from "./src/types/results";
 
 const App: React.FC = () => {
-  const [state, setState] = useState<State>();
+  /* The states are as follows:
+     - null: No search has ever been requested yet.
+     - { searchConcluded: false, { scanID, ...} }: a search is ongoing, for the scan
+       ID scanID. We are waiting for results.
+     - { searchConcluded: true, { scanID, results} }: a search has concluded, and we
+       have saved results in `results`. This scan had ID scanID.
+   */
+  const [state, setState] = useState<State | null>(null);
 
   // This code registers a handler with the VSCode interfacing infrastrucure,
   // outside of this component.
@@ -14,16 +22,51 @@ const App: React.FC = () => {
   // receive results from the extension. To make sure that the component
   // knows to re-render, we will allow `vscode.ts` to call this callback,
   // which will update the state of the component.
-  useEffect(() => {
-    vscode.onChange = (state: State) => {
-      setState(state);
-    };
-  }, []);
+  vscode.onUpdate = (results: ViewResults) => {
+    if (state === null) {
+      vscode.sendMessageToExtension({
+        command: "webview/semgrep/print",
+        message: "Impossible? Webview got results while state was null.",
+      });
+      return;
+    }
+    /* This means that this update is not for the current ongoing search!
+       We probably raced, and future results are coming in.
+       Just ignore it until relevant results come in.
+     */
+    if (state.results.scanID !== results.scanID) {
+      return;
+    }
+
+    /* The search is done! */
+    if (results.locations.length === 0) {
+      setState({ ...state, searchConcluded: true });
+    } else {
+      /* Combine the new results with the saved results! */
+      const newState: State = {
+        searchConcluded: false,
+        results: {
+          locations: state.results.locations.concat(results.locations),
+          scanID: results.scanID,
+        },
+      };
+      setState(newState);
+    }
+  };
+
+  // On a new search, we will generate a new (hopefully) unique scan ID, and wait
+  // to receive results.
+  function onNewSearch(scanID: string) {
+    setState({
+      searchConcluded: false,
+      results: { scanID: scanID, locations: [] },
+    });
+  }
 
   return (
     <main>
-      <TopSection />
-      <SearchResults state={state} />
+      <TopSection onNewSearch={onNewSearch} />
+      {state && <SearchResults state={state} />}
     </main>
   );
 };

--- a/src/webview-ui/src/components/SearchResults/SearchResults.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.tsx
@@ -29,10 +29,12 @@ export const SearchResults: React.FC<SearchResultsProps> = ({ state }) => {
     }
   }
 
+  const status = state.searchConcluded ? "" : "(searching)";
+
   return (
     <div>
       <div className={styles.matchesSummary}>
-        {`${numMatches} matches in ${numFiles} files`}
+        {`${numMatches} matches in ${numFiles} files ${status}`}
         <div className={styles.replaceAllButton} onClick={onFixAll}>
           <VscReplaceAll role="button" title="Replace All" tabIndex={0} />
         </div>

--- a/src/webview-ui/src/components/TopSection/TopSection.tsx
+++ b/src/webview-ui/src/components/TopSection/TopSection.tsx
@@ -2,16 +2,25 @@ import { vscode } from "../../../utilities/vscode";
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { useState } from "react";
 
-export const TopSection: React.FC = () => {
+export function generateUniqueID(): string {
+  return Math.random().toString(36).substring(7);
+}
+export interface TopSectionProps {
+  onNewSearch: (scanID: string) => void;
+}
+export const TopSection: React.FC<TopSectionProps> = ({ onNewSearch }) => {
   const [pattern, setPattern] = useState("");
   const [fix, setFix] = useState("");
 
   function searchQuery(pattern: string, fix: string) {
     const fixValue = fix === "" ? null : fix;
+    const scanID = generateUniqueID();
+    onNewSearch(scanID);
     vscode.sendMessageToExtension({
       command: "webview/semgrep/search",
       pattern: pattern,
       fix: fixValue,
+      scanID: scanID,
     });
   }
 

--- a/src/webview-ui/src/types/results.ts
+++ b/src/webview-ui/src/types/results.ts
@@ -22,5 +22,6 @@ export type ViewResult = {
 };
 
 export type ViewResults = {
+  scanID: string;
   locations: ViewResult[];
 };

--- a/src/webview-ui/src/types/state.ts
+++ b/src/webview-ui/src/types/state.ts
@@ -1,5 +1,6 @@
 import { ViewResults } from "./results";
 
 export type State = {
+  searchConcluded: boolean;
   results: ViewResults;
 };

--- a/src/webview-ui/src/types/state.ts
+++ b/src/webview-ui/src/types/state.ts
@@ -1,5 +1,7 @@
 import { ViewResults } from "./results";
 
+// The state of an ongoing search.
+// We fill up the `results` field as we receive match information!
 export type State = {
   searchConcluded: boolean;
   results: ViewResults;

--- a/src/webview-ui/utilities/vscode.ts
+++ b/src/webview-ui/utilities/vscode.ts
@@ -4,6 +4,7 @@ import {
   webviewToExtensionCommand,
 } from "../../interface/interface";
 import { State } from "../src/types/state";
+import { ViewResults } from "../src/types/results";
 
 /**
  * A utility wrapper around the acquireVsCodeApi() function, which enables
@@ -17,7 +18,7 @@ import { State } from "../src/types/state";
 class VSCodeAPIWrapper {
   private readonly vsCodeApi: WebviewApi<State> | undefined;
   // This is set by the webview App.tsx!
-  public onChange: ((state: State) => void) | null = null;
+  public onUpdate: ((results: ViewResults) => void) | null = null;
 
   constructor() {
     // Check if the acquireVsCodeApi function exists in the current development
@@ -52,13 +53,13 @@ class VSCodeAPIWrapper {
   handleMessageFromExtension(data: extensionToWebviewCommand) {
     switch (data.command) {
       case "extension/semgrep/results": {
-        this.sendMessageToExtension({
-          command: "webview/semgrep/print",
-          message: "Received results from extension",
-        });
+        // this.sendMessageToExtension({
+        //   command: "webview/semgrep/print",
+        //   message: "Received results from extension",
+        // });
         // update the state of the webview component!
-        if (this.onChange) {
-          this.onChange({ results: data.results });
+        if (this.onUpdate) {
+          this.onUpdate(data.results);
         }
       }
     }


### PR DESCRIPTION
This is a stacked diff whose parent is #107.

## What:
This PR introduces the capability to do streaming search, returning results as we get them.

## How:
This is facilitated via continuous communication between webview <-> extension <-> LSP. 

https://github.com/semgrep/semgrep/pull/9933 establishes a protocol that the extension may start an ongoing search with it, and then hit it with `/semgrep/searchOngoing` requests to continually get results out of it.

The extension spawns an asynchronous operation on each new search, whose job is to keep itself alive in a tight loop, constantly querying the LSP and sending the partial results back to the webview. These async threads terminate themselves when a new search is started. 

The webview is responsible for starting searches, and maintains an internal state of the searches for the most recent search request, which it fills up as it receives information from the extension. To make sure we don't race if a request is started while another one is still happening, we spawn unique scan identifiers which are associated to a search request, which the webview uses to ignore out-of-sync messages for out-of-date requests.

## Test plan:
Tested locally.

Closes CDX-293 

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
