### PR TITLE
fix(webview): remove extra padding

### DIFF
--- a/src/searchResultsTree.ts
+++ b/src/searchResultsTree.ts
@@ -102,26 +102,26 @@ export class SemgrepSearchProvider
     this._onDidChange.fire(undefined);
   }
 
-  setSearchItems(results: SearchResult[], params: SearchParams): void {
-    this.lastSearch = params;
-    this.fix_text = params.lspParams.fix;
+  // setSearchItems(results: SearchResult[], params: SearchParams): void {
+  //   this.lastSearch = params;
+  //   this.fix_text = params.fix;
 
-    this.items = results.map((r) => {
-      const uri = vscode.Uri.parse(r.uri);
-      const fi = new FileItem(uri, []);
-      const matches = r.matches.map(
-        (m) =>
-          new MatchItem(new vscode.Range(m.range.start, m.range.end), fi, m.fix)
-      );
-      fi.matches = matches;
-      return fi;
-    });
-    if (this.items.length == 0) {
-      this.items.push(new TextItem("No results found :("));
-    }
+  //   this.items = results.map((r) => {
+  //     const uri = vscode.Uri.parse(r.uri);
+  //     const fi = new FileItem(uri, []);
+  //     const matches = r.matches.map(
+  //       (m) =>
+  //         new MatchItem(new vscode.Range(m.range.start, m.range.end), fi, m.fix)
+  //     );
+  //     fi.matches = matches;
+  //     return fi;
+  //   });
+  //   if (this.items.length == 0) {
+  //     this.items.push(new TextItem("No results found :("));
+  //   }
 
-    this._onDidChange.fire(undefined);
-  }
+  //   this._onDidChange.fire(undefined);
+  // }
 
   async getTreeItem(element: FileItem | MatchItem): Promise<vscode.TreeItem> {
     if (element instanceof MatchItem) {

--- a/src/views/webview.ts
+++ b/src/views/webview.ts
@@ -118,8 +118,10 @@ export class SemgrepSearchWebviewProvider
           <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
           <link rel="stylesheet" type="text/css" href="${stylesUri}">
           <title>Hello World</title>
+          <style>
+          </style>
         </head>
-        <body>
+        <body style="padding: 0">
           <div id="root"></div>
           <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
         </body>

--- a/src/webview-ui/App.css
+++ b/src/webview-ui/App.css
@@ -4,3 +4,7 @@ main {
   height: 100%;
   width: 100%;
 }
+
+body {
+  padding: 0;
+}

--- a/src/webview-ui/src/components/SearchResults/SearchResults.module.css
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.module.css
@@ -2,7 +2,7 @@
 
 .matches-summary {
   color: var(--vscode-search-resultsInfoForeground);
-  padding: 8px 4px 8px;
+  padding: 8px;
   line-height: 1.4em;
   display: flex;
 }

--- a/src/webview-ui/src/components/TopSection/TopSection.tsx
+++ b/src/webview-ui/src/components/TopSection/TopSection.tsx
@@ -29,7 +29,7 @@ export const TopSection: React.FC<TopSectionProps> = ({ onNewSearch }) => {
       <VSCodeTextField
         autofocus
         placeholder="Pattern"
-        style={{ padding: "4px 0", width: "100%" }}
+        style={{ padding: "4px 8px", width: "calc(100% - 16px)" }}
         onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
           if (e.key == "Enter") {
             searchQuery(e.currentTarget.value, fix);
@@ -44,7 +44,7 @@ export const TopSection: React.FC<TopSectionProps> = ({ onNewSearch }) => {
       />
       <VSCodeTextField
         placeholder="Autofix"
-        style={{ padding: "4px 0", width: "100%" }}
+        style={{ padding: "4px 8px", width: "calc(100% - 16px)" }}
         onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
           if (e.key == "Enter") {
             searchQuery(pattern, e.currentTarget.value);


### PR DESCRIPTION
Removes extra padding from the webview UI.

`setSearchItems` has a type error (or did for me), and I think it's unused, so I commented it out

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
