### PR TITLE
feat(search): add language dropdown

### DIFF
--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -14,8 +14,7 @@
  */
 
 import { SUPPORTED_LANGS } from "../constants";
-import { SearchResults } from "../lspExtensions";
-import { ViewResult, ViewResults } from "../webview-ui/src/types/results";
+import { ViewResults } from "../webview-ui/src/types/results";
 import * as vscode from "vscode";
 
 /*****************************************************************************/

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -13,7 +13,9 @@
  * LICENSE for more details.
  */
 
-import { ViewResults } from "../webview-ui/src/types/results";
+import { SUPPORTED_LANGS } from "../constants";
+import { SearchResults } from "../lspExtensions";
+import { ViewResult, ViewResults } from "../webview-ui/src/types/results";
 import * as vscode from "vscode";
 
 /*****************************************************************************/
@@ -41,6 +43,7 @@ export const print = "webview/semgrep/print";
 export const select = "webview/semgrep/select";
 export const replace = "webview/semgrep/replace";
 export const replaceAll = "webview/semgrep/replaceAll";
+export const getLanguage = "webview/semgrep/getActiveLang";
 
 export type webviewToExtensionCommand =
   | {
@@ -50,19 +53,29 @@ export type webviewToExtensionCommand =
       includes: string[];
       excludes: string[];
       scanID: string;
+      lang: SearchLanguage | null; // null means all languages
     }
   | { command: typeof print; message: string }
   | { command: typeof select; uri: string; range: vscode.Range }
   | { command: typeof replace; uri: string; range: vscode.Range; fix: string }
-  | { command: typeof replaceAll; matches: ViewResults };
+  | { command: typeof replaceAll; matches: ViewResults }
+  | { command: typeof getLanguage };
 
 /*****************************************************************************/
 /* Extension to webview commands */
 /*****************************************************************************/
 
 export const results = "extension/semgrep/results";
+export const activeLang = "extension/semgrep/activeLang";
 
-export type extensionToWebviewCommand = {
-  command: typeof results;
-  results: ViewResults;
-};
+export type SearchLanguage = typeof SUPPORTED_LANGS[number];
+
+export type extensionToWebviewCommand =
+  | {
+      command: typeof results;
+      results: ViewResults;
+    }
+  | {
+      command: typeof activeLang;
+      lang: SearchLanguage | null;
+    };

--- a/src/webview-ui/App.tsx
+++ b/src/webview-ui/App.tsx
@@ -65,7 +65,7 @@ const App: React.FC = () => {
 
   return (
     <main>
-      <TopSection onNewSearch={onNewSearch} />
+      <TopSection onNewSearch={onNewSearch} state={state} />
       {state && <SearchResults state={state} />}
     </main>
   );

--- a/src/webview-ui/src/components/SearchResults/SearchResults.module.css
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.module.css
@@ -7,11 +7,6 @@
   display: flex;
 }
 
-.replace-all-button {
-  margin-left: auto;
-  cursor: pointer;
-}
-
 /* ENTRY HEADERS */
 
 .entry-header {

--- a/src/webview-ui/src/components/SearchResults/SearchResults.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.tsx
@@ -20,24 +20,12 @@ export const SearchResults: React.FC<SearchResultsProps> = ({ state }) => {
     return null;
   }
 
-  function onFixAll() {
-    if (state !== undefined) {
-      vscode.sendMessageToExtension({
-        command: "webview/semgrep/replaceAll",
-        matches: state.results,
-      });
-    }
-  }
-
   const status = state.searchConcluded ? "" : "(searching)";
 
   return (
     <div>
       <div className={styles.matchesSummary}>
         {`${numMatches} matches in ${numFiles} files ${status}`}
-        <div className={styles.replaceAllButton} onClick={onFixAll}>
-          <VscReplaceAll role="button" title="Replace All" tabIndex={0} />
-        </div>
       </div>
       {state.results.locations.map((result) => (
         <SearchResultEntry result={result} />

--- a/src/webview-ui/src/components/SearchResults/SearchResults.tsx
+++ b/src/webview-ui/src/components/SearchResults/SearchResults.tsx
@@ -2,8 +2,6 @@ import { State } from "../../types/state";
 
 import styles from "./SearchResults.module.css";
 import { SearchResultEntry } from "./SearchResultEntry";
-import { vscode } from "../../../utilities/vscode";
-import { VscReplaceAll } from "react-icons/vsc";
 
 export interface SearchResultsProps {
   state: State | undefined;

--- a/src/webview-ui/src/components/TopSection/MainInputs.module.css
+++ b/src/webview-ui/src/components/TopSection/MainInputs.module.css
@@ -1,0 +1,19 @@
+.search-row {
+  display: flex;
+  column-gap: 2px;
+  padding: 2px 0;
+}
+
+.replace-all-button {
+  margin-left: auto;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 1px;
+  color: var(--vscode-icon-foreground);
+}
+
+.disabled {
+  color: var(--vscode-disabledForeground);
+}

--- a/src/webview-ui/src/components/TopSection/MainInputs.tsx
+++ b/src/webview-ui/src/components/TopSection/MainInputs.tsx
@@ -29,7 +29,7 @@ export const MainInputs: React.FC<MainInputsProps> = ({
 
   return (
     <>
-      <div className={styles["search-row"]}>
+      <div className={styles.searchRow}>
         <TextBox
           onNewSearch={onNewSearch}
           placeholder="Pattern"
@@ -38,7 +38,7 @@ export const MainInputs: React.FC<MainInputsProps> = ({
         />
         <LangChooser keyName="language" />
       </div>
-      <div className={styles["search-row"]}>
+      <div className={styles.searchRow}>
         <TextBox
           onNewSearch={onNewSearch}
           placeholder="Fix"
@@ -46,8 +46,8 @@ export const MainInputs: React.FC<MainInputsProps> = ({
           keyName="fix"
         />
         <div
-          className={`${styles["replace-all-button"]} ${
-            fixExists ? "" : styles["disabled"]
+          className={`${styles.replaceAllButton} ${
+            fixExists ? "" : styles.disabled
           }`}
           onClick={onFixAll}
         >

--- a/src/webview-ui/src/components/TopSection/MainInputs.tsx
+++ b/src/webview-ui/src/components/TopSection/MainInputs.tsx
@@ -1,23 +1,64 @@
 import { TextBox } from "../utils/TextBox";
+import { vscode } from "../../../utilities/vscode";
+import { LangChooser } from "../utils/LangChooser";
+import { State } from "../../types/state";
+import { VscReplaceAll } from "react-icons/vsc";
+import styles from "./MainInputs.module.css";
 
 export interface MainInputsProps {
   onNewSearch: (scanID: string) => void;
+  state: State | null;
 }
-export const MainInputs: React.FC<MainInputsProps> = ({ onNewSearch }) => {
+export const MainInputs: React.FC<MainInputsProps> = ({
+  onNewSearch,
+  state,
+}) => {
+  function onFixAll() {
+    if (state) {
+      vscode.sendMessageToExtension({
+        command: "webview/semgrep/replaceAll",
+        matches: state.results,
+      });
+    }
+  }
+
+  // enable fix button iff there is at least one match with a pending fix
+  const fixExists = state?.results.locations.some((l) =>
+    l.matches.some((m) => m.searchMatch.fix && !m.isFixed)
+  );
+
   return (
     <>
-      <TextBox
-        onNewSearch={onNewSearch}
-        placeholder="Pattern"
-        isMultiline={true}
-        keyName="pattern"
-      />
-      <TextBox
-        onNewSearch={onNewSearch}
-        placeholder="Fix"
-        isMultiline={true}
-        keyName="fix"
-      />
+      <div className={styles["search-row"]}>
+        <TextBox
+          onNewSearch={onNewSearch}
+          placeholder="Pattern"
+          isMultiline={true}
+          keyName="pattern"
+        />
+        <LangChooser keyName="language" />
+      </div>
+      <div className={styles["search-row"]}>
+        <TextBox
+          onNewSearch={onNewSearch}
+          placeholder="Fix"
+          isMultiline={true}
+          keyName="fix"
+        />
+        <div
+          className={`${styles["replace-all-button"]} ${
+            fixExists ? "" : styles["disabled"]
+          }`}
+          onClick={onFixAll}
+        >
+          <VscReplaceAll
+            role="button"
+            title="Replace All"
+            tabIndex={0}
+            size="1.4em"
+          />
+        </div>
+      </div>
     </>
   );
 };

--- a/src/webview-ui/src/components/TopSection/TopSection.tsx
+++ b/src/webview-ui/src/components/TopSection/TopSection.tsx
@@ -4,16 +4,21 @@ import { MainInputs } from "./MainInputs";
 import styles from "./TopSection.module.css";
 import { VscEllipsis } from "react-icons/vsc";
 import { TextBox } from "../utils/TextBox";
+import { State } from "../../types/state";
 
 export interface TopSectionProps {
   onNewSearch: (scanID: string) => void;
+  state: State | null;
 }
-export const TopSection: React.FC<TopSectionProps> = ({ onNewSearch }) => {
+export const TopSection: React.FC<TopSectionProps> = ({
+  onNewSearch,
+  state,
+}) => {
   const [showOptions, setShowOptions] = useState(false);
 
   return (
     <div className={styles.topSection}>
-      <MainInputs onNewSearch={onNewSearch} />
+      <MainInputs onNewSearch={onNewSearch} state={state} />
       <div>
         <div
           role="button"

--- a/src/webview-ui/src/components/utils/LangChooser.tsx
+++ b/src/webview-ui/src/components/utils/LangChooser.tsx
@@ -1,0 +1,68 @@
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+import { vscode } from "../../utilities/vscode";
+import { SearchLanguage } from "../../../../interface/interface";
+import { FormEventHandler, useState } from "react";
+import { Store, useStore } from "../../hooks/useStore";
+import { SUPPORTED_LANGS } from "../../../../constants";
+
+const style = {
+  // this makes it not quite as weirdly tall
+  //   "--design-unit": "2",
+  // I tried setting the borderRadius directly and it doesn't work.
+  // For some reason it just doesn't show up in the styles.
+  // This does, though.
+  "--corner-radius": "2",
+  //   padding: "0",
+};
+
+export interface LangChooserProps {
+  keyName: keyof Store;
+}
+
+export const LangChooser: React.FC<LangChooserProps> = ({ keyName }) => {
+  const [content, setContent] = useStore(keyName);
+
+  const activeLang = SUPPORTED_LANGS.includes(content as SearchLanguage)
+    ? (content as SearchLanguage)
+    : null;
+
+  const [userHasSelectedLang, setUserHasSelectedLang] =
+    useState<boolean>(false);
+
+  // we need to receive the currently active language from vscode. This
+  // registers a callback that can be called when the activeLang command
+  // is received.
+  vscode.onUpdateActiveLang = (activeLang: SearchLanguage | null) => {
+    // only update the language if the user has not manually selected it.
+    if (userHasSelectedLang) {
+      return;
+    }
+
+    setContent(activeLang ?? "");
+  };
+
+  const handleUpdateLang = (lang: string) => {
+    setUserHasSelectedLang(true);
+    if (lang == "all") {
+      setContent("");
+    }
+    if (SUPPORTED_LANGS.includes(lang as SearchLanguage)) {
+      setContent(lang);
+    } else {
+      throw new Error("Invalid language");
+    }
+  };
+
+  return (
+    <VSCodeDropdown
+      value={activeLang ?? "all"}
+      onChange={(e: any) => handleUpdateLang(e.currentTarget.value)}
+      style={style}
+    >
+      <VSCodeOption>all</VSCodeOption>
+      {SUPPORTED_LANGS.map((l) => (
+        <VSCodeOption>{l}</VSCodeOption>
+      ))}
+    </VSCodeDropdown>
+  );
+};

--- a/src/webview-ui/src/components/utils/LangChooser.tsx
+++ b/src/webview-ui/src/components/utils/LangChooser.tsx
@@ -1,7 +1,7 @@
 import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
 import { vscode } from "../../../utilities/vscode";
 import { SearchLanguage } from "../../../../interface/interface";
-import { FormEventHandler, useState } from "react";
+import { useState } from "react";
 import { Store, useStore } from "../../hooks/useStore";
 import { SUPPORTED_LANGS } from "../../../../constants";
 

--- a/src/webview-ui/src/components/utils/LangChooser.tsx
+++ b/src/webview-ui/src/components/utils/LangChooser.tsx
@@ -1,5 +1,5 @@
 import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
-import { vscode } from "../../utilities/vscode";
+import { vscode } from "../../../utilities/vscode";
 import { SearchLanguage } from "../../../../interface/interface";
 import { FormEventHandler, useState } from "react";
 import { Store, useStore } from "../../hooks/useStore";
@@ -12,7 +12,7 @@ const style = {
   // For some reason it just doesn't show up in the styles.
   // This does, though.
   "--corner-radius": "2",
-  //   padding: "0",
+  padding: "0",
 };
 
 export interface LangChooserProps {

--- a/src/webview-ui/src/components/utils/TextBox.tsx
+++ b/src/webview-ui/src/components/utils/TextBox.tsx
@@ -8,8 +8,8 @@ const style = {
   // For some reason it just doesn't show up in the styles.
   // This does, though.
   "--corner-radius": "2",
+  // padding: "2px 0",
   width: "100%",
-  padding: "2px 0px",
 };
 
 export interface TextBoxProps {

--- a/src/webview-ui/src/hooks/useStore.ts
+++ b/src/webview-ui/src/hooks/useStore.ts
@@ -1,12 +1,15 @@
 import { useEffect } from "react";
 import useLocalStorage from "react-use/lib/useLocalStorage";
 import { vscode } from "../../utilities/vscode";
+import { SUPPORTED_LANGS } from "../../../constants";
+import { SearchLanguage } from "../../../interface/interface";
 
 export interface Store {
   pattern: string;
   fix: string;
   includes: string;
   excludes: string;
+  language: string;
 }
 
 const localStorageKeys: Record<keyof Store, string> = {
@@ -14,6 +17,7 @@ const localStorageKeys: Record<keyof Store, string> = {
   fix: "semgrep-search-fix",
   includes: "semgrep-search-includes",
   excludes: "semgrep-search-excludes",
+  language: "semgrep-search-language",
 };
 
 const store: Record<keyof Store, string> = {
@@ -21,6 +25,7 @@ const store: Record<keyof Store, string> = {
   fix: "",
   includes: "",
   excludes: "",
+  language: "",
 };
 export function generateUniqueID(): string {
   return Math.random().toString(36).substring(7);
@@ -34,6 +39,9 @@ export function useSearch(onNewSearch: (scanID: string) => void): void {
       .filter((s) => s !== "");
   }
   const fixValue = store.fix === "" ? null : store.fix;
+  const lang = SUPPORTED_LANGS.includes(store.language as SearchLanguage)
+    ? (store.language as SearchLanguage)
+    : null;
   const scanID = generateUniqueID();
   // do some naive parsing here
   const includes = splitAndTrim(store.includes);
@@ -46,6 +54,7 @@ export function useSearch(onNewSearch: (scanID: string) => void): void {
     includes: includes,
     excludes: excludes,
     scanID: scanID,
+    lang,
   });
 }
 

--- a/src/webview-ui/utilities/vscode.ts
+++ b/src/webview-ui/utilities/vscode.ts
@@ -50,7 +50,7 @@ class VSCodeAPIWrapper {
     if (this.vsCodeApi) {
       this.vsCodeApi.postMessage(message);
     } else {
-      console.log(message);
+      console.debug(message);
     }
   }
 
@@ -96,8 +96,13 @@ class VSCodeAPIWrapper {
     if (this.vsCodeApi) {
       return this.vsCodeApi.getState();
     } else {
-      const state = localStorage.getItem("vscodeState");
-      return state ? JSON.parse(state) : undefined;
+      try {
+        const state = localStorage.getItem("vscodeState");
+        return state ? JSON.parse(state) : undefined;
+      } catch (e) {
+        console.error("Failed to get state from local storage", e);
+        return undefined;
+      }
     }
   }
 

--- a/src/webview-ui/utilities/vscode.ts
+++ b/src/webview-ui/utilities/vscode.ts
@@ -121,8 +121,13 @@ class VSCodeAPIWrapper {
     if (this.vsCodeApi) {
       return this.vsCodeApi.setState(newState);
     } else {
-      localStorage.setItem("vscodeState", JSON.stringify(newState));
-      return newState;
+      try {
+        localStorage.setItem("vscodeState", JSON.stringify(newState));
+        return newState;
+      } catch (e) {
+        console.error("Failed to set state in local storage", e);
+        return newState;
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a dropdown for language that is automatically populated with the language of the current file (in a janky way that requires VSCode's lang identifiers to line up with semgreps, which they do for python, typescript, and ocaml but don't for others (like bash). We could do a more thorough mapping.

Closes CDX-289
