### PR TITLE
feat: multiple pattern search

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,14 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,12 @@
         "when": "semgrep.cli.minor >= 25 || config.semgrep.ignoreCliVersion"
       },
       {
+        "command": "semgrep.search.exportRule",
+        "title": "Semgrep Search: Export Rule",
+        "icon": "$(search-remove)",
+        "when": "semgrep.cli.minor >= 25 || config.semgrep.ignoreCliVersion"
+      },
+      {
         "command": "semgrep.search.replace",
         "title": "Semgrep Search: Semantic Replace",
         "icon": "$(replace)",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,6 +15,7 @@ import { encodeUri } from "./showAstDocument";
 import { ViewResults } from "./webview-ui/src/types/results";
 import { applyFixAndSave, replaceAll } from "./utils";
 import { handleSearch } from "./search";
+import { useStore } from "./webview-ui/src/hooks/useStore";
 
 /*****************************************************************************/
 /* Prelude */
@@ -164,6 +165,9 @@ export function registerCommands(env: Environment): void {
 
   /* TODO: port to webview */
   vscode.commands.registerCommand("semgrep.search.clear", () => {
+    env.provider?.sendMessageToWebview({
+      command: "extension/semgrep/clear",
+    });
     // env.searchView.clearSearch();
   });
 
@@ -201,6 +205,12 @@ export function registerCommands(env: Environment): void {
   /********/
   /* MISC */
   /********/
+
+  vscode.commands.registerCommand("semgrep.search.exportRule", () => {
+    env.provider?.sendMessageToWebview({
+      command: "extension/semgrep/exportRuleRequest",
+    });
+  });
 
   vscode.commands.registerCommand("semgrep.restartLanguageServer", () => {
     vscode.window.showInformationMessage("Restarting Semgrep Language Server");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -162,12 +162,10 @@ export function registerCommands(env: Environment): void {
     // }
   });
 
-  /* TODO: port to webview */
   vscode.commands.registerCommand("semgrep.search.clear", () => {
     env.provider?.sendMessageToWebview({
       command: "extension/semgrep/clear",
     });
-    // env.searchView.clearSearch();
   });
 
   vscode.commands.registerCommand(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,7 +15,6 @@ import { encodeUri } from "./showAstDocument";
 import { ViewResults } from "./webview-ui/src/types/results";
 import { applyFixAndSave, replaceAll } from "./utils";
 import { handleSearch } from "./search";
-import { useStore } from "./webview-ui/src/hooks/useStore";
 
 /*****************************************************************************/
 /* Prelude */

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -47,7 +47,7 @@ export const getLanguage = "webview/semgrep/getActiveLang";
 export type webviewToExtensionCommand =
   | {
       command: typeof search;
-      pattern: string;
+      patterns: { positive: boolean; pattern: string }[];
       fix: string | null;
       includes: string[];
       excludes: string[];

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -43,6 +43,7 @@ export const select = "webview/semgrep/select";
 export const replace = "webview/semgrep/replace";
 export const replaceAll = "webview/semgrep/replaceAll";
 export const getLanguage = "webview/semgrep/getActiveLang";
+export const exportRule = "webview/semgrep/exportRule";
 
 export type webviewToExtensionCommand =
   | {
@@ -58,7 +59,12 @@ export type webviewToExtensionCommand =
   | { command: typeof select; uri: string; range: vscode.Range }
   | { command: typeof replace; uri: string; range: vscode.Range; fix: string }
   | { command: typeof replaceAll; matches: ViewResults }
-  | { command: typeof getLanguage };
+  | { command: typeof getLanguage }
+  | {
+      command: typeof exportRule;
+      patterns: { positive: boolean; pattern: string }[];
+      language: string;
+    };
 
 /*****************************************************************************/
 /* Extension to webview commands */
@@ -66,6 +72,8 @@ export type webviewToExtensionCommand =
 
 export const results = "extension/semgrep/results";
 export const activeLang = "extension/semgrep/activeLang";
+export const clear = "extension/semgrep/clear";
+export const exportRuleRequest = "extension/semgrep/exportRuleRequest";
 
 export type SearchLanguage = typeof SUPPORTED_LANGS[number];
 
@@ -77,4 +85,6 @@ export type extensionToWebviewCommand =
   | {
       command: typeof activeLang;
       lang: SearchLanguage | null;
-    };
+    }
+  | { command: typeof clear }
+  | { command: typeof exportRuleRequest };

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -38,7 +38,7 @@ export interface SearchParams {
 }
 
 export interface LspSearchParams {
-  pattern: string;
+  patterns: { positive: boolean; pattern: string }[];
   language: string | null;
   fix: string | null;
   includes: string[];

--- a/src/views/webview.ts
+++ b/src/views/webview.ts
@@ -82,6 +82,35 @@ export class SemgrepSearchWebviewProvider
             lang: null,
           });
         }
+        break;
+      }
+      case "webview/semgrep/exportRule": {
+        console.log("opening");
+        const lines = data.patterns
+          .map((pat) =>
+            pat.positive
+              ? `    - pattern: '${pat.pattern}'`
+              : `    - pattern-not: '${pat.pattern}'`
+          )
+          .join("\n");
+        vscode.workspace
+          .openTextDocument({
+            content: [
+              `rules:\n`,
+              `  - id: search-rule\n`,
+              `    language: ${
+                data.language === "all" ? [] : `[${data.language}]`
+              }\n`,
+              `    message: |\n`,
+              `      You can run this rule with Semgrep CLI to search your code and\n`,
+              `      enforce certain practices!\n`,
+              `    severity: ERROR\n`,
+              `    patterns:\n`,
+              `${lines}\n`,
+            ].join(""),
+            language: "yaml",
+          })
+          .then((doc) => vscode.window.showTextDocument(doc));
       }
     }
   }

--- a/src/views/webview.ts
+++ b/src/views/webview.ts
@@ -31,8 +31,8 @@ export class SemgrepSearchWebviewProvider
       case "webview/semgrep/search": {
         const searchParams: SearchParams = {
           lspParams: {
-            pattern: data.pattern,
-            language: null,
+            patterns: data.patterns,
+            language: data.lang,
             fix: data.fix,
             includes: data.includes,
             excludes: data.excludes,

--- a/src/views/webview.ts
+++ b/src/views/webview.ts
@@ -85,7 +85,6 @@ export class SemgrepSearchWebviewProvider
         break;
       }
       case "webview/semgrep/exportRule": {
-        console.log("opening");
         const lines = data.patterns
           .map((pat) =>
             pat.positive

--- a/src/webview-ui/App.tsx
+++ b/src/webview-ui/App.tsx
@@ -6,7 +6,7 @@ import { SearchResults } from "./src/components/SearchResults/SearchResults";
 import { State } from "./src/types/state";
 import { ViewResults } from "./src/types/results";
 import { InfoBlurb } from "./src/components/utils/InfoBlurb";
-import { clearStore, exportRule } from "./src/hooks/useStore";
+import { exportRule, useStore } from "./src/hooks/useStore";
 
 const App: React.FC = () => {
   /* The states are as follows:
@@ -17,11 +17,8 @@ const App: React.FC = () => {
        have saved results in `results`. This scan had ID scanID.
    */
   const [state, setState] = useState<State | null>(null);
-
-  vscode.sendMessageToExtension({
-    command: "webview/semgrep/print",
-    message: "app loaded",
-  });
+  const [_simplePatterns = [], setSimplePatterns] = useStore("simplePatterns");
+  const [_pattern = "", setPattern] = useStore("pattern");
 
   // This code registers a handler with the VSCode interfacing infrastrucure,
   // outside of this component.
@@ -62,7 +59,8 @@ const App: React.FC = () => {
   };
 
   vscode.onClear = () => {
-    clearStore();
+    setPattern("");
+    setSimplePatterns([]);
     setState(null);
   };
   vscode.onExportRule = () => {

--- a/src/webview-ui/App.tsx
+++ b/src/webview-ui/App.tsx
@@ -1,10 +1,12 @@
 import { vscode } from "./utilities/vscode";
 import "./App.css";
 import { useState } from "react";
-import { SearchResults } from "./src/components/SearchResults/SearchResults";
 import { TopSection } from "./src/components/TopSection/TopSection";
+import { SearchResults } from "./src/components/SearchResults/SearchResults";
 import { State } from "./src/types/state";
 import { ViewResults } from "./src/types/results";
+import { InfoBlurb } from "./src/components/utils/InfoBlurb";
+import { clearStore, exportRule } from "./src/hooks/useStore";
 
 const App: React.FC = () => {
   /* The states are as follows:
@@ -15,6 +17,11 @@ const App: React.FC = () => {
        have saved results in `results`. This scan had ID scanID.
    */
   const [state, setState] = useState<State | null>(null);
+
+  vscode.sendMessageToExtension({
+    command: "webview/semgrep/print",
+    message: "app loaded",
+  });
 
   // This code registers a handler with the VSCode interfacing infrastrucure,
   // outside of this component.
@@ -54,6 +61,14 @@ const App: React.FC = () => {
     }
   };
 
+  vscode.onClear = () => {
+    clearStore();
+    setState(null);
+  };
+  vscode.onExportRule = () => {
+    exportRule();
+  };
+
   // On a new search, we will generate a new (hopefully) unique scan ID, and wait
   // to receive results.
   function onNewSearch(scanID: string) {
@@ -66,7 +81,7 @@ const App: React.FC = () => {
   return (
     <main>
       <TopSection onNewSearch={onNewSearch} state={state} />
-      {state && <SearchResults state={state} />}
+      {state ? <SearchResults state={state} /> : <InfoBlurb />}
     </main>
   );
 };

--- a/src/webview-ui/src/components/TopSection/MainInputs.module.css
+++ b/src/webview-ui/src/components/TopSection/MainInputs.module.css
@@ -19,3 +19,38 @@
 .disabled {
   color: var(--vscode-disabledForeground);
 }
+
+.pattern-list {
+  margin-bottom: 5px;
+}
+.add-pattern-button {
+  cursor: pointer;
+  margin-right: 2px;
+  width: 12px;
+  height: 27px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+}
+
+.positivity-button {
+  cursor: pointer;
+  margin-right: 2px;
+  width: 12px;
+  height: 27px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  font-size: 10px;
+  border-radius: 2px;
+}
+
+.delete-pattern-button {
+  cursor: pointer;
+  margin-left: 2px;
+  width: 12px;
+  height: 27px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+}

--- a/src/webview-ui/src/components/TopSection/MainInputs.tsx
+++ b/src/webview-ui/src/components/TopSection/MainInputs.tsx
@@ -6,8 +6,6 @@ import styles from "./MainInputs.module.css";
 import { useStore } from "../../hooks/useStore";
 import { PatternList } from "./PatternList";
 
-type simplePattern = { isPositive: boolean; pattern: string };
-
 export interface MainInputsProps {
   onNewSearch: (scanID: string) => void;
   state: State | null;
@@ -16,7 +14,6 @@ export const MainInputs: React.FC<MainInputsProps> = ({
   onNewSearch,
   state,
 }) => {
-  const [pattern, setPattern] = useStore("pattern");
   const [fix, setFix] = useStore("fix");
 
   function onFixAll() {

--- a/src/webview-ui/src/components/TopSection/MainInputs.tsx
+++ b/src/webview-ui/src/components/TopSection/MainInputs.tsx
@@ -32,7 +32,7 @@ export const MainInputs: React.FC<MainInputsProps> = ({
 
   return (
     <>
-      <PatternList onNewSearch={onNewSearch} state={state} />
+      <PatternList onNewSearch={onNewSearch} />
       <div className={styles.searchRow}>
         <TextBox
           onNewSearch={onNewSearch}

--- a/src/webview-ui/src/components/TopSection/MainInputs.tsx
+++ b/src/webview-ui/src/components/TopSection/MainInputs.tsx
@@ -1,9 +1,12 @@
 import { TextBox } from "../utils/TextBox";
 import { vscode } from "../../../utilities/vscode";
-import { LangChooser } from "../utils/LangChooser";
 import { State } from "../../types/state";
 import { VscReplaceAll } from "react-icons/vsc";
 import styles from "./MainInputs.module.css";
+import { useStore } from "../../hooks/useStore";
+import { PatternList } from "./PatternList";
+
+type simplePattern = { isPositive: boolean; pattern: string };
 
 export interface MainInputsProps {
   onNewSearch: (scanID: string) => void;
@@ -13,6 +16,9 @@ export const MainInputs: React.FC<MainInputsProps> = ({
   onNewSearch,
   state,
 }) => {
+  const [pattern, setPattern] = useStore("pattern");
+  const [fix, setFix] = useStore("fix");
+
   function onFixAll() {
     if (state) {
       vscode.sendMessageToExtension({
@@ -29,21 +35,14 @@ export const MainInputs: React.FC<MainInputsProps> = ({
 
   return (
     <>
-      <div className={styles.searchRow}>
-        <TextBox
-          onNewSearch={onNewSearch}
-          placeholder="Pattern"
-          isMultiline={true}
-          keyName="pattern"
-        />
-        <LangChooser keyName="language" />
-      </div>
+      <PatternList onNewSearch={onNewSearch} state={state} />
       <div className={styles.searchRow}>
         <TextBox
           onNewSearch={onNewSearch}
           placeholder="Fix"
           isMultiline={true}
-          keyName="fix"
+          value={fix}
+          onChange={setFix}
         />
         <div
           className={`${styles.replaceAllButton} ${

--- a/src/webview-ui/src/components/TopSection/PatternBadge.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternBadge.tsx
@@ -36,14 +36,14 @@ export const PatternBadge: React.FC<PatternBadgeProps> = ({
     <div>
       <div
         style={{ backgroundColor: color, height: heightOfAdd }}
-        className={styles["positivity-button"]}
+        className={styles.positivityButton}
         onClick={onPositivityToggle}
       >
         {positive ? <VscAdd /> : <VscCircleSlash />}
       </div>
       {last && (
         <div
-          className={styles["add-pattern-button"]}
+          className={styles.addPatternButton}
           style={{ height: heightOfChevron, marginTop: "4px" }}
           onClick={onNewPattern}
         >

--- a/src/webview-ui/src/components/TopSection/PatternBadge.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternBadge.tsx
@@ -1,0 +1,55 @@
+import { vscode } from "./../../utilities/vscode";
+import {
+  VSCodeButton,
+  VSCodeTextArea,
+  VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react";
+import { useEffect, useState } from "react";
+import { TextBox } from "../utils/TextBox";
+import { LangChooser } from "../utils/LangChooser";
+import styles from "./MainInputs.module.css";
+import { State } from "../../types/state";
+import { VscReplaceAll, VscAdd, VscChevronDown } from "react-icons/vsc";
+import { useStore } from "../../hooks/useStore";
+import { isLast, simplePattern } from "./PatternList";
+import { VscCircleSlash } from "react-icons/vsc";
+
+export interface PatternBadgeProps {
+  index: number | null;
+  patterns: simplePattern[];
+  isPositive: boolean;
+  onNewPattern: () => void;
+  onPositivityToggle: () => void;
+}
+export const PatternBadge: React.FC<PatternBadgeProps> = ({
+  onNewPattern,
+  index,
+  patterns,
+  isPositive,
+  onPositivityToggle,
+}) => {
+  const last = isLast(index, patterns);
+  const color = isPositive ? "#458c4c" : "#a23636";
+  const heightOfAdd = last ? "15px" : "27px";
+  const heightOfChevron = last ? "7px" : "0px";
+  return (
+    <div>
+      <div
+        style={{ backgroundColor: color, height: heightOfAdd }}
+        className={styles["positivity-button"]}
+        onClick={onPositivityToggle}
+      >
+        {isPositive ? <VscAdd /> : <VscCircleSlash />}
+      </div>
+      {last && (
+        <div
+          className={styles["add-pattern-button"]}
+          style={{ height: heightOfChevron, marginTop: "4px" }}
+          onClick={onNewPattern}
+        >
+          <VscChevronDown />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/webview-ui/src/components/TopSection/PatternBadge.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternBadge.tsx
@@ -1,16 +1,5 @@
-import { vscode } from "./../../utilities/vscode";
-import {
-  VSCodeButton,
-  VSCodeTextArea,
-  VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react";
-import { useEffect, useState } from "react";
-import { TextBox } from "../utils/TextBox";
-import { LangChooser } from "../utils/LangChooser";
 import styles from "./MainInputs.module.css";
-import { State } from "../../types/state";
-import { VscReplaceAll, VscAdd, VscChevronDown } from "react-icons/vsc";
-import { useStore } from "../../hooks/useStore";
+import { VscAdd, VscChevronDown } from "react-icons/vsc";
 import { isLast, simplePattern } from "./PatternList";
 import { VscCircleSlash } from "react-icons/vsc";
 

--- a/src/webview-ui/src/components/TopSection/PatternBadge.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternBadge.tsx
@@ -17,7 +17,7 @@ import { VscCircleSlash } from "react-icons/vsc";
 export interface PatternBadgeProps {
   index: number | null;
   patterns: simplePattern[];
-  isPositive: boolean;
+  positive: boolean;
   onNewPattern: () => void;
   onPositivityToggle: () => void;
 }
@@ -25,11 +25,11 @@ export const PatternBadge: React.FC<PatternBadgeProps> = ({
   onNewPattern,
   index,
   patterns,
-  isPositive,
+  positive,
   onPositivityToggle,
 }) => {
   const last = isLast(index, patterns);
-  const color = isPositive ? "#458c4c" : "#a23636";
+  const color = positive ? "#458c4c" : "#a23636";
   const heightOfAdd = last ? "15px" : "27px";
   const heightOfChevron = last ? "7px" : "0px";
   return (
@@ -39,7 +39,7 @@ export const PatternBadge: React.FC<PatternBadgeProps> = ({
         className={styles["positivity-button"]}
         onClick={onPositivityToggle}
       >
-        {isPositive ? <VscAdd /> : <VscCircleSlash />}
+        {positive ? <VscAdd /> : <VscCircleSlash />}
       </div>
       {last && (
         <div

--- a/src/webview-ui/src/components/TopSection/PatternList.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternList.tsx
@@ -5,6 +5,7 @@ import styles from "./MainInputs.module.css";
 import { VscClose } from "react-icons/vsc";
 import { useStore } from "../../hooks/useStore";
 import { PatternBadge } from "./PatternBadge";
+import { vscode } from "../../../utilities/vscode";
 
 export type simplePattern = { positive: boolean; pattern: string };
 

--- a/src/webview-ui/src/components/TopSection/PatternList.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternList.tsx
@@ -1,0 +1,113 @@
+import { vscode } from "./../../utilities/vscode";
+import {
+  VSCodeButton,
+  VSCodeTextArea,
+  VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react";
+import { useEffect, useState } from "react";
+import { TextBox } from "../utils/TextBox";
+import { LangChooser } from "../utils/LangChooser";
+import styles from "./MainInputs.module.css";
+import { State } from "../../types/state";
+import {
+  VscReplaceAll,
+  VscAdd,
+  VscChevronDown,
+  VscClose,
+} from "react-icons/vsc";
+import { useStore } from "../../hooks/useStore";
+import { PatternBadge } from "./PatternBadge";
+
+export type simplePattern = { isPositive: boolean; pattern: string };
+
+export function isLast(index: number | null, patterns: simplePattern[]) {
+  return (
+    (index === null && patterns.length === 0) || index === patterns.length - 1
+  );
+}
+
+export interface PatternListProps {
+  onNewSearch: (scanID: string) => void;
+  state: State | null;
+}
+export const PatternList: React.FC<PatternListProps> = ({
+  onNewSearch,
+  state,
+}) => {
+  const [pattern, setPattern] = useStore("pattern");
+  const [patterns, setPatterns] = useState<simplePattern[]>([]);
+
+  const [numRerenders, setNumRerenders] = useState(0);
+
+  function setPatternAtIndex(index: number | null, p: simplePattern) {
+    if (index === null) {
+      setPattern(p.pattern);
+    } else {
+      patterns[index] = p;
+      setPatterns(patterns);
+      setNumRerenders(numRerenders + 1);
+    }
+  }
+
+  function deletePatternAtIndex(index: number | null) {
+    if (index === null) {
+      return;
+    }
+    patterns.splice(index, 1);
+    setPatterns(patterns);
+    setNumRerenders(numRerenders + 1);
+  }
+
+  function onNewPattern() {
+    const newPatterns = patterns.concat({ isPositive: true, pattern: "" });
+    setPatterns(newPatterns);
+    setNumRerenders(numRerenders + 1);
+  }
+
+  function mk(p: simplePattern, index: number | null) {
+    return (
+      <div className={styles["search-row"]}>
+        <PatternBadge
+          isPositive={p.isPositive}
+          onPositivityToggle={() =>
+            setPatternAtIndex(index, {
+              isPositive: !p.isPositive,
+              pattern: p.pattern,
+            })
+          }
+          onNewPattern={onNewPattern}
+          patterns={patterns}
+          index={index}
+        />
+        <TextBox
+          onNewSearch={onNewSearch}
+          placeholder="Pattern"
+          isMultiline={true}
+          value={p.pattern}
+          onChange={(value: string) =>
+            setPatternAtIndex(index, {
+              isPositive: p.isPositive,
+              pattern: value,
+            })
+          }
+        />
+        {index === null ? (
+          <LangChooser keyName="language" />
+        ) : (
+          <div
+            className={styles["delete-pattern-button"]}
+            onClick={() => deletePatternAtIndex(index)}
+          >
+            <VscClose />
+          </div>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className={styles["pattern-list"]}>
+      {mk({ isPositive: true, pattern: pattern }, null)}
+      {patterns.map((p: simplePattern, index: number) => mk(p, index))}
+    </div>
+  );
+};

--- a/src/webview-ui/src/components/TopSection/PatternList.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternList.tsx
@@ -18,7 +18,7 @@ import {
 import { useStore } from "../../hooks/useStore";
 import { PatternBadge } from "./PatternBadge";
 
-export type simplePattern = { isPositive: boolean; pattern: string };
+export type simplePattern = { positive: boolean; pattern: string };
 
 export function isLast(index: number | null, patterns: simplePattern[]) {
   return (
@@ -35,7 +35,7 @@ export const PatternList: React.FC<PatternListProps> = ({
   state,
 }) => {
   const [pattern, setPattern] = useStore("pattern");
-  const [patterns, setPatterns] = useState<simplePattern[]>([]);
+  const [patterns, setPatterns] = useStore("simplePatterns");
 
   const [numRerenders, setNumRerenders] = useState(0);
 
@@ -59,19 +59,19 @@ export const PatternList: React.FC<PatternListProps> = ({
   }
 
   function onNewPattern() {
-    const newPatterns = patterns.concat({ isPositive: true, pattern: "" });
+    const newPatterns = patterns.concat({ positive: true, pattern: "" });
     setPatterns(newPatterns);
     setNumRerenders(numRerenders + 1);
   }
 
-  function mk(p: simplePattern, index: number | null) {
+  function mkPattern(p: simplePattern, index: number | null) {
     return (
       <div className={styles["search-row"]}>
         <PatternBadge
-          isPositive={p.isPositive}
+          positive={p.positive}
           onPositivityToggle={() =>
             setPatternAtIndex(index, {
-              isPositive: !p.isPositive,
+              positive: !p.positive,
               pattern: p.pattern,
             })
           }
@@ -86,7 +86,7 @@ export const PatternList: React.FC<PatternListProps> = ({
           value={p.pattern}
           onChange={(value: string) =>
             setPatternAtIndex(index, {
-              isPositive: p.isPositive,
+              positive: p.positive,
               pattern: value,
             })
           }
@@ -106,8 +106,8 @@ export const PatternList: React.FC<PatternListProps> = ({
   }
   return (
     <div className={styles["pattern-list"]}>
-      {mk({ isPositive: true, pattern: pattern }, null)}
-      {patterns.map((p: simplePattern, index: number) => mk(p, index))}
+      {mkPattern({ positive: true, pattern: pattern }, null)}
+      {patterns.map((p: simplePattern, index: number) => mkPattern(p, index))}
     </div>
   );
 };

--- a/src/webview-ui/src/components/TopSection/PatternList.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternList.tsx
@@ -1,26 +1,17 @@
-import { vscode } from "./../../utilities/vscode";
-import {
-  VSCodeButton,
-  VSCodeTextArea,
-  VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { TextBox } from "../utils/TextBox";
 import { LangChooser } from "../utils/LangChooser";
 import styles from "./MainInputs.module.css";
-import { State } from "../../types/state";
-import {
-  VscReplaceAll,
-  VscAdd,
-  VscChevronDown,
-  VscClose,
-} from "react-icons/vsc";
+import { VscClose } from "react-icons/vsc";
 import { useStore } from "../../hooks/useStore";
 import { PatternBadge } from "./PatternBadge";
 
 export type simplePattern = { positive: boolean; pattern: string };
 
-export function isLast(index: number | null, patterns: simplePattern[]) {
+export function isLast(
+  index: number | null,
+  patterns: simplePattern[]
+): boolean {
   return (
     (index === null && patterns.length === 0) || index === patterns.length - 1
   );
@@ -28,12 +19,8 @@ export function isLast(index: number | null, patterns: simplePattern[]) {
 
 export interface PatternListProps {
   onNewSearch: (scanID: string) => void;
-  state: State | null;
 }
-export const PatternList: React.FC<PatternListProps> = ({
-  onNewSearch,
-  state,
-}) => {
+export const PatternList: React.FC<PatternListProps> = ({ onNewSearch }) => {
   const [pattern, setPattern] = useStore("pattern");
   const [patterns, setPatterns] = useStore("simplePatterns");
 

--- a/src/webview-ui/src/components/TopSection/PatternList.tsx
+++ b/src/webview-ui/src/components/TopSection/PatternList.tsx
@@ -66,7 +66,7 @@ export const PatternList: React.FC<PatternListProps> = ({
 
   function mkPattern(p: simplePattern, index: number | null) {
     return (
-      <div className={styles["search-row"]}>
+      <div className={styles.searchRow}>
         <PatternBadge
           positive={p.positive}
           onPositivityToggle={() =>
@@ -95,7 +95,7 @@ export const PatternList: React.FC<PatternListProps> = ({
           <LangChooser keyName="language" />
         ) : (
           <div
-            className={styles["delete-pattern-button"]}
+            className={styles.deletePatternButton}
             onClick={() => deletePatternAtIndex(index)}
           >
             <VscClose />
@@ -105,7 +105,7 @@ export const PatternList: React.FC<PatternListProps> = ({
     );
   }
   return (
-    <div className={styles["pattern-list"]}>
+    <div className={styles.patternList}>
       {mkPattern({ positive: true, pattern: pattern }, null)}
       {patterns.map((p: simplePattern, index: number) => mkPattern(p, index))}
     </div>

--- a/src/webview-ui/src/components/TopSection/TopSection.tsx
+++ b/src/webview-ui/src/components/TopSection/TopSection.tsx
@@ -6,6 +6,7 @@ import { VscEllipsis } from "react-icons/vsc";
 import { TextBox } from "../utils/TextBox";
 import { State } from "../../types/state";
 import { MatchesSummary } from "./MatchesSummary";
+import { useStore } from "../../hooks/useStore";
 
 export interface TopSectionProps {
   onNewSearch: (scanID: string) => void;
@@ -16,6 +17,8 @@ export const TopSection: React.FC<TopSectionProps> = ({
   state,
 }) => {
   const [showOptions, setShowOptions] = useState(false);
+  const [includes, setIncludes] = useStore("includes");
+  const [excludes, setExcludes] = useStore("excludes");
 
   return (
     <div className={styles.topSection}>
@@ -33,7 +36,8 @@ export const TopSection: React.FC<TopSectionProps> = ({
             description="files to include"
             onNewSearch={onNewSearch}
             isMultiline={false}
-            keyName="includes"
+            value={includes}
+            onChange={setIncludes}
           />
         )}
         {showOptions && (
@@ -41,7 +45,8 @@ export const TopSection: React.FC<TopSectionProps> = ({
             description="files to exclude"
             onNewSearch={onNewSearch}
             isMultiline={false}
-            keyName="excludes"
+            value={excludes}
+            onChange={setExcludes}
           />
         )}
       </div>

--- a/src/webview-ui/src/components/utils/InfoBlurb.tsx
+++ b/src/webview-ui/src/components/utils/InfoBlurb.tsx
@@ -1,0 +1,18 @@
+import { vscode } from "./../../utilities/vscode";
+import {
+  VSCodeButton,
+  VSCodeTextArea,
+  VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react";
+import { useEffect, useState } from "react";
+import { Store, useSearch, useStore } from "../../hooks/useStore";
+
+export const InfoBlurb: React.FC = () => {
+  return (
+    <div style={{ paddingLeft: "10px", paddingTop: "15px" }}>
+      Hi, and welcome to the Semgrep VS Code Extension!
+      <br />
+      Type a Semgrep pattern below to get started.
+    </div>
+  );
+};

--- a/src/webview-ui/src/components/utils/InfoBlurb.tsx
+++ b/src/webview-ui/src/components/utils/InfoBlurb.tsx
@@ -1,12 +1,3 @@
-import { vscode } from "./../../utilities/vscode";
-import {
-  VSCodeButton,
-  VSCodeTextArea,
-  VSCodeTextField,
-} from "@vscode/webview-ui-toolkit/react";
-import { useEffect, useState } from "react";
-import { Store, useSearch, useStore } from "../../hooks/useStore";
-
 export const InfoBlurb: React.FC = () => {
   return (
     <div style={{ paddingLeft: "10px", paddingTop: "15px" }}>

--- a/src/webview-ui/src/components/utils/TextBox.tsx
+++ b/src/webview-ui/src/components/utils/TextBox.tsx
@@ -1,5 +1,5 @@
 import { VSCodeTextArea } from "@vscode/webview-ui-toolkit/react";
-import { Store, useSearch, useStore } from "../../hooks/useStore";
+import { useSearch } from "../../hooks/useStore";
 
 const style = {
   // this makes it not quite as weirdly tall

--- a/src/webview-ui/src/components/utils/TextBox.tsx
+++ b/src/webview-ui/src/components/utils/TextBox.tsx
@@ -14,7 +14,8 @@ const style = {
 export interface TextBoxProps {
   onNewSearch: (scanID: string) => void;
   isMultiline: boolean;
-  keyName: keyof Store;
+  value: string;
+  onChange: (value: string) => void;
   placeholder?: string;
   description?: string;
 }
@@ -22,11 +23,11 @@ export const TextBox: React.FC<TextBoxProps> = ({
   onNewSearch,
   placeholder,
   isMultiline,
-  keyName,
+  value,
+  onChange,
   description,
 }) => {
-  const [content, setContent] = useStore(keyName);
-  const numRows = isMultiline ? content.split("\n").length : 1;
+  const numRows = isMultiline ? value.split("\n").length : 1;
 
   return (
     <>
@@ -43,12 +44,12 @@ export const TextBox: React.FC<TextBoxProps> = ({
             useSearch(onNewSearch);
           }
         }}
-        value={content}
+        value={value}
         // I literally have no idea what the type of this or the below handler should be
         // We use the onChange here because there's a delta between when the onKeyPress
         // is fired and when the value is updated
         onInput={(e: any) => {
-          setContent(e.target.value);
+          onChange(e.target.value);
         }}
       />
     </>

--- a/src/webview-ui/src/hooks/useStore.ts
+++ b/src/webview-ui/src/hooks/useStore.ts
@@ -23,14 +23,19 @@ const localStorageKeys: Record<keyof Store, string> = {
   simplePatterns: "semgrep-search-simple-patterns",
 };
 
-const store: Store = {
-  pattern: "",
-  fix: "",
-  includes: "",
-  excludes: "",
-  language: "",
-  simplePatterns: [],
-};
+function defaultStore() {
+  return {
+    pattern: "",
+    fix: "",
+    includes: "",
+    excludes: "",
+    language: "",
+    simplePatterns: [],
+  };
+}
+
+const store: Store = defaultStore();
+
 export function generateUniqueID(): string {
   return Math.random().toString(36).substring(7);
 }
@@ -79,4 +84,53 @@ export function useStore(key: keyof Store): [any, (value: any) => void] {
     }, [field, key]);
     return [field, setField];
   }
+}
+
+export function clearStore() {
+  vscode.sendMessageToExtension({
+    command: "webview/semgrep/print",
+    message: "in cleastore",
+  });
+  const newStore = defaultStore();
+  vscode.sendMessageToExtension({
+    command: "webview/semgrep/print",
+    message: "in cleastore 2",
+  });
+  // for (const k in store) {
+  // vscode.sendMessageToExtension({
+  //   command: "webview/semgrep/print",
+  //   message: `key ${k}`
+  // })
+  //   const key: keyof Store = k as keyof Store;
+  //   if (key === "simplePatterns") {
+  //     const [field = [], setField] = useLocalStorage(localStorageKeys[key], []);
+  //     store[key] = newStore[key];
+  //     setField(newStore[key]);
+  //   } else {
+  //     const [field = "", setField] = useLocalStorage(localStorageKeys[key], "");
+  //     store[key] = newStore[key];
+  //     setField(newStore[key])
+  //   }
+  // }
+  const [field = "", setField] = useLocalStorage(
+    localStorageKeys["pattern"],
+    ""
+  );
+  setField("'");
+  localStorage.clear();
+  vscode.sendMessageToExtension({
+    command: "webview/semgrep/print",
+    message: `store is ${JSON.stringify(store)}`,
+  });
+}
+
+export function exportRule() {
+  vscode.sendMessageToExtension({
+    command: "webview/semgrep/exportRule",
+    patterns: [
+      { positive: true, pattern: store.pattern },
+      ...store.simplePatterns,
+    ],
+    language: store.language,
+  });
 }

--- a/src/webview-ui/src/hooks/useStore.ts
+++ b/src/webview-ui/src/hooks/useStore.ts
@@ -3,6 +3,7 @@ import useLocalStorage from "react-use/lib/useLocalStorage";
 import { vscode } from "../../utilities/vscode";
 import { SUPPORTED_LANGS } from "../../../constants";
 import { SearchLanguage } from "../../../interface/interface";
+import { simplePattern } from "../components/TopSection/PatternList";
 
 export interface Store {
   pattern: string;
@@ -10,7 +11,7 @@ export interface Store {
   includes: string;
   excludes: string;
   language: string;
-  simplePatterns: string[];
+  simplePatterns: simplePattern[];
 }
 
 const localStorageKeys: Record<keyof Store, string> = {
@@ -52,7 +53,10 @@ export function useSearch(onNewSearch: (scanID: string) => void): void {
   onNewSearch(scanID);
   vscode.sendMessageToExtension({
     command: "webview/semgrep/search",
-    pattern: store.pattern,
+    patterns: [
+      { positive: true, pattern: store.pattern },
+      ...store.simplePatterns,
+    ],
     fix: fixValue,
     includes: includes,
     excludes: excludes,

--- a/src/webview-ui/src/hooks/useStore.ts
+++ b/src/webview-ui/src/hooks/useStore.ts
@@ -10,6 +10,7 @@ export interface Store {
   includes: string;
   excludes: string;
   language: string;
+  simplePatterns: string[];
 }
 
 const localStorageKeys: Record<keyof Store, string> = {
@@ -18,14 +19,16 @@ const localStorageKeys: Record<keyof Store, string> = {
   includes: "semgrep-search-includes",
   excludes: "semgrep-search-excludes",
   language: "semgrep-search-language",
+  simplePatterns: "semgrep-search-simple-patterns",
 };
 
-const store: Record<keyof Store, string> = {
+const store: Store = {
   pattern: "",
   fix: "",
   includes: "",
   excludes: "",
   language: "",
+  simplePatterns: [],
 };
 export function generateUniqueID(): string {
   return Math.random().toString(36).substring(7);
@@ -58,10 +61,18 @@ export function useSearch(onNewSearch: (scanID: string) => void): void {
   });
 }
 
-export function useStore(key: keyof Store): [string, (value: string) => void] {
-  const [field = "", setField] = useLocalStorage(localStorageKeys[key], "");
-  useEffect(() => {
-    store[key] = field;
-  }, [field, key]);
-  return [field, setField];
+export function useStore(key: keyof Store): [any, (value: any) => void] {
+  if (key === "simplePatterns") {
+    const [field = [], setField] = useLocalStorage(localStorageKeys[key], []);
+    useEffect(() => {
+      store[key] = field;
+    }, [field, key]);
+    return [field, setField];
+  } else {
+    const [field = "", setField] = useLocalStorage(localStorageKeys[key], "");
+    useEffect(() => {
+      store[key] = field;
+    }, [field, key]);
+    return [field, setField];
+  }
 }

--- a/src/webview-ui/src/hooks/useStore.ts
+++ b/src/webview-ui/src/hooks/useStore.ts
@@ -77,6 +77,8 @@ export function useStore(key: keyof Store): [any, (value: any) => void] {
       store[key] = field;
     }, [field, key]);
     return [field, setField];
+    // annoying code duplication here because simplePatterns has a different type of
+    // data that it is storing, vs the other keys
   } else {
     const [field = "", setField] = useLocalStorage(localStorageKeys[key], "");
     useEffect(() => {
@@ -87,41 +89,13 @@ export function useStore(key: keyof Store): [any, (value: any) => void] {
 }
 
 export function clearStore() {
-  vscode.sendMessageToExtension({
-    command: "webview/semgrep/print",
-    message: "in cleastore",
-  });
-  const newStore = defaultStore();
-  vscode.sendMessageToExtension({
-    command: "webview/semgrep/print",
-    message: "in cleastore 2",
-  });
-  // for (const k in store) {
-  // vscode.sendMessageToExtension({
-  //   command: "webview/semgrep/print",
-  //   message: `key ${k}`
-  // })
-  //   const key: keyof Store = k as keyof Store;
-  //   if (key === "simplePatterns") {
-  //     const [field = [], setField] = useLocalStorage(localStorageKeys[key], []);
-  //     store[key] = newStore[key];
-  //     setField(newStore[key]);
-  //   } else {
-  //     const [field = "", setField] = useLocalStorage(localStorageKeys[key], "");
-  //     store[key] = newStore[key];
-  //     setField(newStore[key])
-  //   }
-  // }
-  const [field = "", setField] = useLocalStorage(
-    localStorageKeys["pattern"],
-    ""
-  );
-  setField("'");
-  localStorage.clear();
-  vscode.sendMessageToExtension({
-    command: "webview/semgrep/print",
-    message: `store is ${JSON.stringify(store)}`,
-  });
+  const [_ = "", setField] = useLocalStorage(localStorageKeys["pattern"], "");
+  setField("");
+  try {
+    localStorage.clear();
+  } catch (e) {
+    console.error("error clearing store", e);
+  }
 }
 
 export function exportRule() {

--- a/src/webview-ui/src/hooks/useStore.ts
+++ b/src/webview-ui/src/hooks/useStore.ts
@@ -88,16 +88,6 @@ export function useStore(key: keyof Store): [any, (value: any) => void] {
   }
 }
 
-export function clearStore() {
-  const [_ = "", setField] = useLocalStorage(localStorageKeys["pattern"], "");
-  setField("");
-  try {
-    localStorage.clear();
-  } catch (e) {
-    console.error("error clearing store", e);
-  }
-}
-
 export function exportRule() {
   vscode.sendMessageToExtension({
     command: "webview/semgrep/exportRule",

--- a/src/webview-ui/utilities/vscode.ts
+++ b/src/webview-ui/utilities/vscode.ts
@@ -23,6 +23,8 @@ class VSCodeAPIWrapper {
   public onUpdateActiveLang:
     | ((activeLang: SearchLanguage | null) => void)
     | null = null;
+  public onClear: (() => void) | null = null;
+  public onExportRule: (() => void) | null = null;
 
   constructor() {
     // Check if the acquireVsCodeApi function exists in the current development
@@ -82,6 +84,18 @@ class VSCodeAPIWrapper {
         });
         if (this.onUpdateActiveLang) {
           this.onUpdateActiveLang(data.lang);
+        }
+        break;
+      }
+      case "extension/semgrep/clear": {
+        if (this.onClear) {
+          this.onClear();
+        }
+        break;
+      }
+      case "extension/semgrep/exportRuleRequest": {
+        if (this.onExportRule) {
+          this.onExportRule();
         }
       }
     }


### PR DESCRIPTION
This is a stacked diff whose parent is #117 

## What:
This PR makes it so that you can specify _multiple_ patterns to the Semgrep Search bar, which you may toggle to be either positive or negative. Negative matches will be removed. They are all under an implicit `all`.

## Why:
Searching with a single pattern is reasonably limited. You can only search for things expressible in a single pattern, and you cannot filter anything out. This makes it rather difficult to use effectively, especially in the context of mass refactor, when you want to make sure you are only matching things which are relevant to you.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
