### PR TITLE
feat: `loggedIn` context key

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
               "markdown": "walkthrough/2-sign-in.md"
             },
             "completionEvents": [
-              "onCommand:semgrep.login"
+              "onContext:semgrep.loggedIn"
             ]
           },
           {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,18 +1,20 @@
+import * as fs from "fs";
+import * as vscode from "vscode";
 import {
   ExtensionContext,
   OutputChannel,
+  window,
+  workspace,
   WorkspaceConfiguration,
 } from "vscode";
-import { window, workspace } from "vscode";
-import * as fs from "fs";
 
-import { VSCODE_CONFIG_KEY, VSCODE_EXT_NAME } from "./constants";
-import { Logger } from "./utils";
-import { SemgrepDocumentProvider } from "./showAstDocument";
-import { LanguageClient } from "vscode-languageclient/node";
 import { EventEmitter } from "stream";
-import { SemgrepSearchWebviewProvider } from "./views/webview";
+import { LanguageClient } from "vscode-languageclient/node";
+import { VSCODE_CONFIG_KEY, VSCODE_EXT_NAME } from "./constants";
+import { SemgrepDocumentProvider } from "./showAstDocument";
 import { setSentryContext } from "./telemetry/sentry";
+import { Logger } from "./utils";
+import { SemgrepSearchWebviewProvider } from "./views/webview";
 
 export class Config {
   get cfg(): WorkspaceConfiguration {
@@ -73,6 +75,7 @@ export class Environment {
   }
 
   set loggedIn(val: boolean) {
+    vscode.commands.executeCommand("setContext", "semgrep.loggedIn", val);
     this.context.globalState.update("loggedIn", val);
   }
 


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

This creates a context key, which we can consume in a variety of places
to determine if we should enable some feature (See
<https://code.visualstudio.com/api/references/when-clause-contexts>).

For instance, an updated walkthrough could make use of this, and we can
use it to choose what views to show at the vscode level too.